### PR TITLE
Feature/buddy ac console

### DIFF
--- a/venues/ICLR.cc/2020/Conference/python/buddyAcCommentProcess.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAcCommentProcess.js
@@ -8,7 +8,7 @@ function(){
     .then(function(result) {
 
       var forumNote = result.notes[0];
-      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chairs';
+      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chair1';
       var BUDDY_AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Buddy_Area_Chair1';
       var buddy_ac_regex = /Buddy/;
 

--- a/venues/ICLR.cc/2020/Conference/python/buddyAcCommentProcess.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAcCommentProcess.js
@@ -1,0 +1,47 @@
+function(){
+    var or3client = lib.or3client;
+
+    var CONFERENCE_ID = 'ICLR.cc/2020/Conference';
+    var SHORT_PHRASE = 'ICLR 2020';
+
+    or3client.or3request(or3client.notesUrl + '?id=' + note.forum, {}, 'GET', token)
+    .then(function(result) {
+
+      var forumNote = result.notes[0];
+      var AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chairs';
+      var BUDDY_AREA_CHAIRS_ID = CONFERENCE_ID + '/Paper' + forumNote.number + '/Buddy_Area_Chair1';
+      var buddy_ac_regex = /Buddy/;
+
+      var ac_mail = {
+        groups: [AREA_CHAIRS_ID],
+        subject: '[' + SHORT_PHRASE + '] Comment posted by your buddy AC to a paper in your area. Paper Number: ' + forumNote.number + ', Paper Title: "' + forumNote.content.title + '"',
+        message: 'A comment was posted by your buddy Area Chair to a paper for which you are serving as the primary Area Chair.\n\nPaper Number: ' + forumNote.number + '\n\nPaper Title: "' + forumNote.content.title + '"\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+      };
+
+      var buddy_ac_mail = {
+        groups: [BUDDY_AREA_CHAIRS_ID],
+        subject: '[' + SHORT_PHRASE + '] Comment posted to a paper for which you are a buddy AC. Paper Number: ' + forumNote.number + ', Paper Title: "' + forumNote.content.title + '"',
+        message: 'A comment was posted by the primary Area Chair to a paper for which you are serving as buddy Area Chair.\n\nPaper Number: ' + forumNote.number + '\n\nPaper Title: "' + forumNote.content.title + '"\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+      };
+
+      var comment_author_mail = {
+        groups: [note.tauthor],
+        subject: '[' + SHORT_PHRASE + '] Your comment was received on Paper Number: ' + forumNote.number + ', Paper Title: "' + forumNote.content.title + '"',
+        message: 'Your comment was received on a submission to ' + SHORT_PHRASE + '.\n\nPaper Number: ' + forumNote.number + '\n\nPaper Title: "' + forumNote.content.title + '"\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+      };
+
+      var promises = [];
+      promises.push(or3client.or3request(or3client.mailUrl, comment_author_mail, 'POST', token));
+      if (note.signatures[0].match(buddy_ac_regex)){
+        promises.push(or3client.or3request(or3client.mailUrl, ac_mail, 'POST', token));
+      } else {
+        promises.push(or3client.or3request(or3client.mailUrl, buddy_ac_mail, 'POST', token));
+      }
+
+      return Promise.all(promises);
+    })
+    .then(result => done())
+    .catch(error => done(error));
+
+    return true;
+};

--- a/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
@@ -570,7 +570,7 @@ var renderTableRows = function(rows, container) {
       return '<h4>Avg: ' + data.averageConfidence + '</h4><span>Min: ' + data.minConfidence + '</span>' +
         '<br><span>Max: ' + data.maxConfidence + '</span>';
     },
-    Handlebars.templates.noteMetaReviewStatus
+    Handlebars.templates.noteMetaReviewStatusBuddy
   ];
 
   var rowsHtml = rows.map(function(row) {
@@ -582,7 +582,7 @@ var renderTableRows = function(rows, container) {
   var tableHtml = Handlebars.templates['components/table']({
     headings: [
       '<input type="checkbox" id="select-all-papers">', '#', 'Paper Summary',
-      'Review Progress', 'Rating', 'Confidence', 'Status'
+      'Review Progress', 'Rating', 'Confidence', 'Meta Review Status'
     ],
     rows: rowsHtml,
     extraClasses: 'ac-console-table'

--- a/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
@@ -1,0 +1,984 @@
+// Constants
+var CONFERENCE_ID = 'ICLR.cc/2020/Conference';
+var SHORT_PHRASE = 'ICLR 2020';
+var SUBMISSION_ID = 'ICLR.cc/2020/Conference/-/Submission';
+var BLIND_SUBMISSION_ID = 'ICLR.cc/2020/Conference/-/Blind_Submission';
+var HEADER = {"title": "Buddy Area Chairs Console", "instructions": "<p class=\"dark\">This page provides information and status             updates for the Papers assigned to you in your role as a Buddy Area Chair for ICLR 2020.</p>", "schedule": "<h4>Coming Soon</h4>            <p>                <em><strong>Please check back later for updates.</strong></em>            </p>"};
+var AREA_CHAIR_NAME = 'Area_Chairs';
+var BUDDY_AREA_CHAIR_NAME = 'Buddy_Area_Chairs';
+var REVIEWER_NAME = 'Reviewers';
+var OFFICIAL_REVIEW_NAME = 'Official_Review';
+var OFFICIAL_META_REVIEW_NAME = 'Meta_Review';
+var LEGACY_INVITATION_ID = false;
+var ENABLE_REVIEWER_REASSIGNMENT = false;
+
+var WILDCARD_INVITATION = CONFERENCE_ID + '.*';
+var ANONREVIEWER_WILDCARD = CONFERENCE_ID + '/Paper.*/AnonReviewer.*';
+var BUDDY_AREACHAIR_WILDCARD = CONFERENCE_ID + '/Paper.*/Buddy_Area_Chair.*';
+var REVIEWER_GROUP = CONFERENCE_ID + '/' + REVIEWER_NAME;
+
+var reviewerSummaryMap = {};
+var allReviewers = [];
+
+// Main function is the entry point to the webfield code
+var main = function() {
+  OpenBanner.venueHomepageLink(CONFERENCE_ID);
+
+  renderHeader();
+
+  Webfield.get('/groups', {
+    member: user.id, regex: BUDDY_AREACHAIR_WILDCARD
+  })
+  .then(loadData)
+  .then(formatData)
+  .then(renderTableAndTasks)
+  .fail(function() {
+    Webfield.ui.errorMessage();
+  });
+};
+
+
+// Util functions
+var findProfile = function(profiles, id) {
+  var profile = _.find(profiles, function(p) {
+    return _.find(p.content.names, function(n) { return n.username == id; }) || _.includes(p.content.emails, id);
+  });
+  if (profile) {
+    return profile;
+  } else {
+    return {
+      id: id,
+      name: '',
+      email: id,
+      content: {
+        names: [{ username: id }]
+      }
+    }
+  }
+}
+
+var getNumberfromGroup = function(groupId, name) {
+
+  var tokens = groupId.split('/');
+  paper = _.find(tokens, function(token) { return token.startsWith(name); });
+  if (paper) {
+    return parseInt(paper.replace(name, ''));
+  } else {
+    return null;
+  }
+};
+
+var getPaperNumbersfromGroups = function(groups) {
+  return _.filter(_.map(groups, function(group) {
+    return getNumberfromGroup(group.id, 'Paper');
+  }), _.isInteger);
+};
+
+var buildNoteMap = function(noteNumbers) {
+  var noteMap = Object.create(null);
+  for (var i = 0; i < noteNumbers.length; i++) {
+    noteMap[noteNumbers[i]] = Object.create(null);
+    reviewerSummaryMap[noteNumbers[i]] = Object.create(null);
+  }
+  return noteMap;
+};
+
+var getInvitationId = function(name, number) {
+  if (LEGACY_INVITATION_ID) {
+    return CONFERENCE_ID + '/-/Paper' + number + '/' + name;
+  }
+  return CONFERENCE_ID + '/Paper' + number + '/-/' + name;
+}
+
+var getInvitationRegex = function(name, numberStr) {
+  if (LEGACY_INVITATION_ID) {
+    return '^' + CONFERENCE_ID + '/-/Paper(' + numberStr + ')/' + name;
+  }
+  return '^' + CONFERENCE_ID + '/Paper(' + numberStr + ')/-/' + name;
+}
+
+// Ajax functions
+var loadData = function(result) {
+  var noteNumbers = getPaperNumbersfromGroups(result.groups);
+  var blindedNotesP;
+  var metaReviewsP;
+  var allReviewersP;
+
+  if (noteNumbers.length) {
+    var noteNumbersStr = noteNumbers.join(',');
+
+    blindedNotesP = Webfield.getAll('/notes', {
+      invitation: BLIND_SUBMISSION_ID, number: noteNumbersStr, noDetails: true
+    });
+
+    var noteNumberRegex = noteNumbers.join('|');
+    metaReviewsP = Webfield.getAll('/notes', {
+      invitation: getInvitationRegex(OFFICIAL_META_REVIEW_NAME, noteNumberRegex), noDetails: true
+    });
+  } else {
+    blindedNotesP = $.Deferred().resolve([]);
+    metaReviewsP = $.Deferred().resolve([]);
+  }
+
+  var invitationsP = Webfield.getAll('/invitations', {
+    regex: WILDCARD_INVITATION, invitee: true,
+    duedate: true, replyto: true, details: 'replytoNote,repliedNotes'
+  });
+
+  var tagInvitationsP = Webfield.getAll('/invitations', {
+    regex: WILDCARD_INVITATION,
+    invitee: true,
+    duedate: true,
+    tags: true,
+    details:'repliedTags'
+  });
+
+  if (ENABLE_REVIEWER_REASSIGNMENT) {
+    allReviewersP = Webfield.get('/groups', { id: REVIEWER_GROUP })
+    .then(function(result) {
+      allReviewers = result.groups[0].members;
+    });
+  } else {
+    allReviewersP = $.Deferred().resolve([]);
+  }
+
+  return $.when(
+    blindedNotesP,
+    getOfficialReviews(noteNumbers),
+    metaReviewsP,
+    getReviewerGroups(noteNumbers),
+    invitationsP,
+    tagInvitationsP,
+    allReviewersP
+  );
+};
+
+var getOfficialReviews = function(noteNumbers) {
+  if (!noteNumbers.length) {
+    return $.Deferred().resolve({});
+  }
+
+  var noteMap = buildNoteMap(noteNumbers);
+
+  return Webfield.getAll('/notes', {
+    invitation: getInvitationRegex(OFFICIAL_REVIEW_NAME, noteNumbers.join('|')), noDetails: true
+  })
+  .then(function(notes) {
+    var ratingExp = /^(\d+): .*/;
+
+    _.forEach(notes, function(n) {
+      var num = getNumberfromGroup(n.signatures[0], 'Paper');
+      var index = getNumberfromGroup(n.signatures[0], 'AnonReviewer');
+      if (num) {
+        if (num in noteMap) {
+          // Need to parse rating and confidence strings into ints
+          ratingMatch = n.content.rating.match(ratingExp);
+          n.rating = ratingMatch ? parseInt(ratingMatch[1], 10) : null;
+          confidenceMatch = n.content.confidence.match(ratingExp);
+          n.confidence = confidenceMatch ? parseInt(confidenceMatch[1], 10) : null;
+
+          noteMap[num][index] = n;
+        }
+      }
+    });
+
+    return noteMap;
+  });
+};
+
+var getReviewerGroups = function(noteNumbers) {
+  if (!noteNumbers.length) {
+    return $.Deferred().resolve({});
+  };
+
+  var noteMap = buildNoteMap(noteNumbers);
+
+  return Webfield.getAll('/groups', { regex: ANONREVIEWER_WILDCARD })
+  .then(function(groups) {
+    _.forEach(groups, function(g) {
+      var num = getNumberfromGroup(g.id, 'Paper');
+      var index = getNumberfromGroup(g.id, 'AnonReviewer');
+      if (num) {
+        if ((num in noteMap) && g.members.length) {
+          noteMap[num][index] = g.members[0];
+        }
+      }
+    });
+
+    return noteMap;
+  });
+};
+
+var formatData = function(blindedNotes, officialReviews, metaReviews, noteToReviewerIds, invitations, tagInvitations, allReviewers) {
+  var uniqueIds = _.uniq(_.reduce(noteToReviewerIds, function(result, idsObj, noteNum) {
+    return result.concat(_.values(idsObj));
+  }, []));
+
+  return getUserProfiles(uniqueIds)
+  .then(function(profiles) {
+    return {
+      profiles: profiles,
+      blindedNotes: blindedNotes,
+      officialReviews: officialReviews,
+      metaReviews: metaReviews,
+      noteToReviewerIds: noteToReviewerIds,
+      invitations: invitations,
+      tagInvitations: tagInvitations
+    };
+  });
+};
+
+var displayError = function(message) {
+  message = message || 'The group data could not be loaded.';
+  $('#notes').empty().append('<div class="alert alert-danger"><strong>Error:</strong> ' + message + '</div>');
+};
+
+var getUserProfiles = function(userIds) {
+  var ids = _.filter(userIds, function(id) { return _.startsWith(id, '~');});
+  var emails = _.filter(userIds, function(id) { return id.match(/.+@.+/);});
+
+  var profileSearch = [];
+  if (ids.length) {
+    profileSearch.push(Webfield.post('/profiles/search', {ids: ids}),);
+  }
+  if (emails.length) {
+    profileSearch.push(Webfield.post('/profiles/search', {emails: emails}));
+  }
+
+  return $.when.apply($, profileSearch)
+  .then(function() {
+    var searchResults = _.toArray(arguments);
+    var profileMap = {};
+    if (!searchResults) {
+      return profileMap;
+    }
+    var addProfileToMap = function(profile) {
+      var name = _.find(profile.content.names, ['preferred', true]) || _.first(profile.content.names);
+      profile.name = _.isEmpty(name) ? view.prettyId(profile.id) : name.first + ' ' + name.last;
+      profile.email = profile.content.preferredEmail || profile.content.emails[0];
+      profileMap[profile.id] = profile;
+    };
+    _.forEach(searchResults, function(result) {
+      _.forEach(result.profiles, addProfileToMap);
+    });
+    return profileMap;
+  })
+  .fail(function(error) {
+    displayError();
+    return null;
+  });
+};
+
+// Render functions
+var renderHeader = function() {
+  Webfield.ui.setup('#group-container', CONFERENCE_ID);
+  Webfield.ui.header(HEADER.title, HEADER.instructions);
+
+  var loadingMessage = '<p class="empty-message">Loading...</p>';
+  Webfield.ui.tabPanel([
+    {
+      heading: 'Assigned Papers',
+      id: 'assigned-papers',
+      content: loadingMessage,
+      extraClasses: 'horizontal-scroll',
+      active: true
+    },
+    {
+      heading: 'Buddy AC Schedule',
+      id: 'areachair-schedule',
+      content: HEADER.schedule
+    },
+    {
+      heading: 'Buddy AC Tasks',
+      id: 'areachair-tasks',
+      content: loadingMessage
+    }
+  ]);
+};
+
+var renderStatusTable = function(profiles, notes, completedReviews, metaReviews, reviewerIds, container) {
+  var rows = _.map(notes, function(note) {
+    var revIds = reviewerIds[note.number] || Object.create(null);
+    for (var revNumber in revIds) {
+      var uId = revIds[revNumber];
+      revIds[revNumber] = findProfile(profiles, uId);
+    }
+
+    var metaReview = _.find(metaReviews, ['invitation', getInvitationId(OFFICIAL_META_REVIEW_NAME, note.number)]);
+    var noteCompletedReviews = completedReviews[note.number] || Object.create(null);
+
+    return buildTableRow(note, revIds, noteCompletedReviews, metaReview);
+  });
+
+  // Sort form handler
+  var order = 'desc';
+  var sortOptions = {
+    Paper_Number: function(row) { return row[1].number; },
+    Paper_Title: function(row) { return _.toLower(_.trim(row[2].content.title)); },
+    Number_of_Reviews_Submitted: function(row) { return row[3].numSubmittedReviews; },
+    Number_of_Reviews_Missing: function(row) { return row[3].numReviewers - row[3].numSubmittedReviews; },
+    Average_Rating: function(row) { return row[4].averageRating === 'N/A' ? 0 : row[4].averageRating; },
+    Max_Rating: function(row) { return row[4].maxRating === 'N/A' ? 0 : row[4].maxRating; },
+    Min_Rating: function(row) { return row[4].minRating === 'N/A' ? 0 : row[4].minRating; },
+    Average_Confidence: function(row) { return row[5].averageConfidence === 'N/A' ? 0 : row[5].averageConfidence; },
+    Max_Confidence: function(row) { return row[5].maxConfidence === 'N/A' ? 0 : row[5].maxConfidence; },
+    Min_Confidence: function(row) { return row[5].minConfidence === 'N/A' ? 0 : row[5].minConfidence; },
+    Meta_Review_Rating: function(row) { return row[6].recommendation ? _.toInteger(row[6].recommendation.split(':')[0]) : 0; }
+  };
+  var sortResults = function(newOption, switchOrder) {
+    if (switchOrder) {
+      order = order === 'asc' ? 'desc' : 'asc';
+    }
+    renderTableRows(_.orderBy(rows, sortOptions[newOption], order), container);
+  }
+
+  // Message modal handler
+  var sendReviewerReminderEmailsStep1 = function(e) {
+    var subject = $('#message-reviewers-modal input[name="subject"]').val().trim();
+    var message = $('#message-reviewers-modal textarea[name="message"]').val().trim();
+    var filter  = $(this)[0].dataset["filter"];
+
+    var count = 0;
+    var selectedRows = rows;
+    var reviewerMessages = [];
+    var reviewerCounts = Object.create(null);
+    var selectedIds = _.map(
+      $('.ac-console-table input.select-note-reviewers:checked'),
+      function(checkbox) { return $(checkbox).data('noteId'); }
+    );
+    selectedRows = rows.filter(function(row) {
+      return _.includes(selectedIds, row[2].forum);
+    });
+
+    selectedRows.forEach(function(row) {
+      var users = _.values(row[3].reviewers);
+      if (filter === 'msg-submitted-reviewers') {
+        users = users.filter(function(u) {
+          return u.completedReview;
+        });
+      } else if (filter === 'msg-unsubmitted-reviewers') {
+        users = users.filter(function(u) {
+          return !u.completedReview;
+        });
+      }
+
+      if (users.length) {
+        var forumUrl = 'https://openreview.net/forum?' + $.param({
+          id: row[2].forum,
+          noteId: row[2].id,
+          invitationId: getInvitationId(OFFICIAL_REVIEW_NAME, row[2].number)
+        });
+        reviewerMessages.push({
+          groups: _.map(users, 'id'),
+          forumUrl: forumUrl,
+          subject: subject,
+          message: message,
+        });
+
+        users.forEach(function(u) {
+          if (u.id in reviewerCounts) {
+            reviewerCounts[u.id].count++;
+          } else {
+            reviewerCounts[u.id] = {
+              name: u.name,
+              email: u.email,
+              count: 1
+            };
+          }
+        });
+
+        count += users.length;
+      }
+    });
+    localStorage.setItem('reviewerMessages', JSON.stringify(reviewerMessages));
+    localStorage.setItem('messageCount', count);
+
+    // Show step 2
+    var namesHtml = _.flatMap(reviewerCounts, function(obj) {
+      var text = obj.name + ' <span>&lt;' + obj.email + '&gt;</span>';
+      if (obj.count > 1) {
+        text += ' (&times;' + obj.count + ')';
+      }
+      return text;
+    }).join(', ');
+    $('#message-reviewers-modal .reviewer-list').html(namesHtml);
+    $('#message-reviewers-modal .num-reviewers').text(count);
+    $('#message-reviewers-modal .step-1').hide();
+    $('#message-reviewers-modal .step-2').show();
+
+    return false;
+  };
+
+  var sendReviewerReminderEmailsStep2 = function(e) {
+    var reviewerMessages = localStorage.getItem('reviewerMessages');
+    var messageCount = localStorage.getItem('messageCount');
+    if (!reviewerMessages || !messageCount) {
+      $('#message-reviewers-modal').modal('hide');
+      promptError('Could not send emails at this time. Please refresh the page and try again.');
+    }
+    JSON.parse(reviewerMessages).forEach(postReviewerEmails);
+
+    localStorage.removeItem('reviewerMessages');
+    localStorage.removeItem('messageCount');
+
+    $('#message-reviewers-modal').modal('hide');
+    promptMessage('Successfully sent ' + messageCount + ' emails');
+  };
+
+  var sortOptionHtml = Object.keys(sortOptions).map(function(option) {
+    return '<option value="' + option + '">' + option.replace(/_/g, ' ') + '</option>';
+  }).join('\n');
+
+  var sortBarHtml = '<form class="form-inline search-form clearfix" role="search">' +
+    '<div id="div-msg-reviewers" class="btn-group" role="group">' +
+      '<button id="message-reviewers-btn" type="button" class="btn btn-icon dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select papers to message corresponding reviewers" disabled="disabled">' +
+        '<span class="glyphicon glyphicon-envelope"></span> &nbsp;Message Reviewers ' +
+        '<span class="caret"></span>' +
+      '</button>' +
+      '<ul class="dropdown-menu" aria-labelledby="grp-msg-reviewers-btn">' +
+        '<li><a id="msg-all-reviewers">All Reviewers of selected papers</a></li>' +
+        '<li><a id="msg-submitted-reviewers">Reviewers of selected papers with submitted reviews</a></li>' +
+        '<li><a id="msg-unsubmitted-reviewers">Reviewers of selected papers with unsubmitted reviews</a></li>' +
+      '</ul>' +
+    '</div>' +
+    '<div class="pull-right">' +
+      '<strong>Sort By:</strong> ' +
+      '<select id="form-sort" class="form-control">' + sortOptionHtml + '</select>' +
+      '<button id="form-order" class="btn btn-icon"><span class="glyphicon glyphicon-sort"></span></button>' +
+    '</div>' +
+  '</form>';
+  if (rows.length) {
+    $(container).empty().append(sortBarHtml);
+  }
+
+  // Need to add event handlers for these controls inside this function so they have access to row
+  // data
+  $('#form-sort').on('change', function(e) {
+    sortResults($(e.target).val(), false);
+  });
+  $('#form-order').on('click', function(e) {
+    sortResults($(this).prev().val(), true);
+    return false;
+  });
+
+  $('#div-msg-reviewers').find("a").on('click', function(e) {
+    var filter = $(this)[0].id;
+    $('#message-reviewers-modal').remove();
+
+    var defaultBody = "";
+    if (filter === "msg-unsubmitted-reviewers"){
+      defaultBody = 'This is a reminder to please submit your review for ' + SHORT_PHRASE + '. ' +
+      'Click on the link below to go to the review page:\n\n[[SUBMIT_REVIEW_LINK]]' +
+      '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair';
+    } else {
+      defaultBody = 'Click on the link below to go to the review page:\n\n[[SUBMIT_REVIEW_LINK]]' +
+      '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair';
+    }
+
+    var modalHtml = Handlebars.templates.messageReviewersModalFewerOptions({
+      filter: filter,
+      defaultSubject: SHORT_PHRASE + ' Reminder',
+      defaultBody: defaultBody,
+    });
+    $('body').append(modalHtml);
+
+    $('#message-reviewers-modal .btn-primary.step-1').on('click', sendReviewerReminderEmailsStep1);
+    $('#message-reviewers-modal .btn-primary.step-2').on('click', sendReviewerReminderEmailsStep2);
+    $('#message-reviewers-modal form').on('submit', sendReviewerReminderEmailsStep1);
+
+    $('#message-reviewers-modal').modal();
+
+    if ($('.ac-console-table input.select-note-reviewers:checked').length) {
+      $('#message-reviewers-modal select[name="group"]').val('selected');
+    }
+    return false;
+  });
+
+  if (rows.length) {
+    renderTableRows(rows, container);
+  } else {
+    $(container).empty().append('<p class="empty-message">No assigned papers. ' +
+      'Check back later or contact info@openreview.net if you believe this to be an error.</p>');
+  }
+};
+
+var updateReviewerContainer = function(paperNumber) {
+  $addReviewerContainer = $('#' + paperNumber + '-add-reviewer');
+  $reviewerProgressContainer = $('#' + paperNumber + '-reviewer-progress');
+  paperForum = $reviewerProgressContainer.data('paperForum');
+
+  var dropdownOptions = _.map(allReviewers, function(member) {
+    return {
+      id: member,
+      description: view.prettyId(member)
+    };
+  });
+  var filterOptions = function(options, term) {
+    return _.filter(options, function(p) {
+      return _.includes(p.description.toLowerCase(), term.toLowerCase());
+    });
+  };
+  placeholder = 'reviewer@domain.edu';
+
+  var $dropdown = view.mkDropdown(placeholder, false, null, function(update, term) {
+    update(filterOptions(dropdownOptions, term));
+  }, function(value, id) {
+    var selectedOption = _.find(dropdownOptions, ['id', id]);
+    var $input = $dropdown.find('input');
+
+    if (!(selectedOption && selectedOption.description === value)) {
+      $input.val(value);
+      $input.attr('value_id', value);
+    } else {
+      $input.val(value);
+      $input.attr('value_id', id);
+    }
+  });
+
+  $dropdown.find('input').attr({
+    class: 'form-control dropdown note_content_value input-assign-reviewer',
+    name: placeholder,
+    autocomplete: 'on'
+  });
+  $dropdown.find('div').attr({
+    class: 'dropdown_content dropdown_content_assign_reviewer',
+    name: placeholder,
+    autocomplete: 'on'
+  });
+
+  $addReviewerContainer.append($dropdown);
+  $addReviewerContainer.append('<button class="btn btn-xs btn-assign-reviewer" data-paper-number=' + paperNumber + ' data-paper-forum=' + paperForum +'>Assign</button>');
+}
+
+var renderTableRows = function(rows, container) {
+  var templateFuncs = [
+    function(data) {
+      var checked = data.selected ? 'checked="checked"' : '';
+      return '<label><input type="checkbox" class="select-note-reviewers" data-note-id="' +
+        data.noteId + '" ' + checked + '></label>';
+    },
+    function(data) {
+      return '<strong class="note-number">' + data.number + '</strong>';
+    },
+    Handlebars.templates.noteSummary,
+    Handlebars.templates.noteReviewers,
+    function(data) {
+      return '<h4>Avg: ' + data.averageRating + '</h4><span>Min: ' + data.minRating + '</span>' +
+        '<br><span>Max: ' + data.maxRating + '</span>';
+    },
+    function(data) {
+      return '<h4>Avg: ' + data.averageConfidence + '</h4><span>Min: ' + data.minConfidence + '</span>' +
+        '<br><span>Max: ' + data.maxConfidence + '</span>';
+    },
+    Handlebars.templates.noteMetaReviewStatus
+  ];
+
+  var rowsHtml = rows.map(function(row) {
+    return row.map(function(cell, i) {
+      return templateFuncs[i](cell);
+    });
+  });
+
+  var tableHtml = Handlebars.templates['components/table']({
+    headings: [
+      '<input type="checkbox" id="select-all-papers">', '#', 'Paper Summary',
+      'Review Progress', 'Rating', 'Confidence', 'Status'
+    ],
+    rows: rowsHtml,
+    extraClasses: 'ac-console-table'
+  });
+
+  $('.table-container', container).remove();
+  $(container).append(tableHtml);
+
+  if (ENABLE_REVIEWER_REASSIGNMENT) {
+    for(key in reviewerSummaryMap) {
+      updateReviewerContainer(key);
+    }
+  }
+}
+
+var renderTasks = function(invitations, tagInvitations) {
+  //  My Tasks tab
+  var tasksOptions = {
+    container: '#areachair-tasks',
+    emptyMessage: 'No outstanding tasks for this conference'
+  }
+  $(tasksOptions.container).empty();
+
+  // Filter out non-areachair tasks
+  var filterFunc = function(inv) {
+    return _.some(inv.invitees, function(invitee) { return invitee.indexOf(BUDDY_AREA_CHAIR_NAME) !== -1; });
+  };
+  var areachairInvitations = _.filter(invitations, filterFunc);
+  var areachairTagInvitations = _.filter(tagInvitations, filterFunc);
+
+  Webfield.ui.newTaskList(areachairInvitations, areachairTagInvitations, tasksOptions);
+  $('.tabs-container a[href="#areachair-tasks"]').parent().show();
+}
+
+var renderTableAndTasks = function(fetchedData) {
+  renderTasks(fetchedData.invitations, fetchedData.tagInvitations);
+
+  renderStatusTable(
+    fetchedData.profiles,
+    fetchedData.blindedNotes,
+    fetchedData.officialReviews,
+    fetchedData.metaReviews,
+    _.cloneDeep(fetchedData.noteToReviewerIds), // Need to clone this dictionary because some values are missing after the first refresh
+    '#assigned-papers'
+  );
+
+  registerEventHandlers();
+
+  Webfield.ui.done();
+}
+
+var buildTableRow = function(note, reviewerIds, completedReviews, metaReview) {
+  var cellCheck = { selected: false, noteId: note.id };
+
+  // Paper number cell
+  var cell0 = { number: note.number};
+
+  // Note summary cell
+  note.content.authors = null;  // Don't display 'Blinded Authors'
+  var cell1 = note;
+
+  // Review progress cell
+  var reviewObj;
+  var combinedObj = {};
+  var ratings = [];
+  var confidences = [];
+  for (var reviewerNum in reviewerIds) {
+    var reviewer = reviewerIds[reviewerNum];
+    if (reviewerNum in completedReviews) {
+      reviewObj = completedReviews[reviewerNum];
+      combinedObj[reviewerNum] = {
+        id: reviewer.id,
+        name: reviewer.name,
+        email: reviewer.email,
+        completedReview: true,
+        forum: reviewObj.forum,
+        note: reviewObj.id,
+        rating: reviewObj.rating,
+        confidence: reviewObj.confidence,
+        reviewLength: reviewObj.content.review.length
+      };
+      ratings.push(reviewObj.rating);
+      confidences.push(reviewObj.confidence);
+    } else {
+      var forumUrl = 'https://openreview.net/forum?' + $.param({
+        id: note.forum,
+        noteId: note.id,
+        invitationId: getInvitationId(OFFICIAL_REVIEW_NAME, note.number)
+      });
+      var lastReminderSent = localStorage.getItem(forumUrl + '|' + reviewer.id);
+      combinedObj[reviewerNum] = {
+        id: reviewer.id,
+        name: reviewer.name,
+        email: reviewer.email,
+        forum: note.forum,
+        forumUrl: forumUrl,
+        lastReminderSent: lastReminderSent ? new Date(parseInt(lastReminderSent)).toLocaleDateString() : lastReminderSent,
+        paperNumber: note.number,
+        reviewerNumber: reviewerNum
+      };
+    }
+  }
+
+  var cell2 = {
+    noteId: note.id,
+    paperNumber: note.number,
+    numSubmittedReviews: Object.keys(completedReviews).length,
+    numReviewers: Object.keys(reviewerIds).length,
+    reviewers: combinedObj,
+    sendReminder: true,
+    expandReviewerList: false,
+    enableReviewerReassignment : ENABLE_REVIEWER_REASSIGNMENT
+  };
+  reviewerSummaryMap[note.number] = cell2;
+
+  // Rating cell
+  var cell3 = {
+    averageRating: 'N/A',
+    minRating: 'N/A',
+    maxRating: 'N/A'
+  };
+  if (ratings.length) {
+    cell3.averageRating = _.round(_.sum(ratings) / ratings.length, 2);
+    cell3.minRating = _.min(ratings);
+    cell3.maxRating = _.max(ratings);
+  }
+
+  // Confidence cell
+  var cell4 = {
+    averageConfidence: 'N/A',
+    minConfidence: 'N/A',
+    maxConfidence: 'N/A'
+  };
+  if (confidences.length) {
+    cell4.averageConfidence = _.round(_.sum(confidences) / confidences.length, 2);
+    cell4.minConfidence = _.min(confidences);
+    cell4.maxConfidence = _.max(confidences);
+  }
+
+  // Status cell
+  var invitationUrlParams = {
+    id: note.forum,
+    noteId: note.id,
+    invitationId: getInvitationId('Meta_Review', note.number)
+  };
+  var cell5 = {
+    invitationUrl: '/forum?' + $.param(invitationUrlParams)
+  };
+  if (metaReview) {
+    cell5.recommendation = metaReview.content.recommendation;
+    cell5.editUrl = '/forum?id=' + note.forum + '&noteId=' + metaReview.id;
+  }
+
+  return [cellCheck, cell0, cell1, cell2, cell3, cell4, cell5];
+};
+
+var findNextAnonGroupNumber = function(paperNumber){
+  paperReviewerNums = Object.keys(reviewerSummaryMap[paperNumber].reviewers).sort();
+  for (var i = 1; i < paperReviewerNums.length + 1; i++) {
+    if (i.toString() !== paperReviewerNums[i-1]) {
+      return i;
+    }
+  }
+  return paperReviewerNums.length + 1;
+}
+
+// Event Handlers
+var registerEventHandlers = function() {
+  $('#group-container').on('click', 'a.note-contents-toggle', function(e) {
+    var hiddenText = 'Show paper details';
+    var visibleText = 'Hide paper details';
+    var updated = $(this).text() === hiddenText ? visibleText : hiddenText;
+    $(this).text(updated);
+  });
+
+  $('#group-container').on('click', 'a.send-reminder-link', function(e) {
+    var $link = $(this);
+    var userId = $link.data('userId');
+    var forumUrl = $link.data('forumUrl');
+
+    var sendReviewerReminderEmails = function(e) {
+      var postData = {
+        groups: [userId],
+        forumUrl: forumUrl,
+        subject: $('#message-reviewers-modal input[name="subject"]').val().trim(),
+        message: $('#message-reviewers-modal textarea[name="message"]').val().trim(),
+      };
+
+      $('#message-reviewers-modal').modal('hide');
+      // promptMessage('Your reminder email has been sent to ' + view.prettyId(userId));
+      postReviewerEmails(postData);
+      $link.after(' (Last sent: ' + (new Date()).toLocaleDateString() + ')');
+
+      return false;
+    };
+
+    var modalHtml = Handlebars.templates.messageReviewersModalFewerOptions({
+      singleRecipient: true,
+      reviewerId: userId,
+      forumUrl: forumUrl,
+      defaultSubject: SHORT_PHRASE + ' Reminder',
+      defaultBody: 'This is a reminder to please submit your review for ' + SHORT_PHRASE + '. ' +
+        'Click on the link below to go to the review page:\n\n[[SUBMIT_REVIEW_LINK]]' +
+        '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair',
+    });
+    $('#message-reviewers-modal').remove();
+    $('body').append(modalHtml);
+
+    $('#message-reviewers-modal .btn-primary').on('click', sendReviewerReminderEmails);
+    $('#message-reviewers-modal form').on('submit', sendReviewerReminderEmails);
+
+    $('#message-reviewers-modal').modal();
+    return false;
+  });
+
+  $('#group-container').on('click', 'a.collapse-btn', function(e) {
+    if ($(this).text() === 'Show reviewers') {
+      $(this).text('Hide reviewers');
+    } else {
+      $(this).text('Show reviewers');
+    }
+  });
+
+  $('#group-container').on('click', 'button.btn.btn-assign-reviewer', function(e) {
+    var $link = $(this);
+    var paperNumber = $link.data('paperNumber');
+    var paperForum = $link.data('paperForum');
+    var $currDiv = $('#' + paperNumber + '-add-reviewer');
+    var userToAdd = $currDiv.find('input').attr('value_id').trim();
+
+    if (!userToAdd) {
+      promptError('Please enter a valid email for assigning a reviewer');
+      return false;
+    }
+    var alreadyAssigned = _.find(reviewerSummaryMap[paperNumber].reviewers, function(rev){
+      return (rev.email === userToAdd) || (rev.id === userToAdd);
+    });
+    if (alreadyAssigned) {
+      promptError('Reviewer ' + view.prettyId(userToAdd) + ' has already been assigned to Paper ' + paperNumber.toString());
+      return false;
+    }
+
+    var nextAnonNumber = findNextAnonGroupNumber(paperNumber);
+    var reviewerProfile = {
+      'email' : userToAdd,
+      'id' : userToAdd,
+      'name': '',
+      'content': {'names': [{'username': userToAdd}]}
+    };
+
+    getUserProfiles([userToAdd])
+    .then(function (userProfile){
+      if (userProfile && Object.keys(userProfile).length){
+        reviewerProfile = userProfile[Object.keys(userProfile)[0]];
+      }
+      Webfield.put('/groups/members', {
+        id: CONFERENCE_ID + '/Paper' + paperNumber + '/Reviewers',
+        members: [reviewerProfile.id]
+      })
+    })
+    .then(function(result) {
+      return Webfield.post('/groups', {
+        id: CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + nextAnonNumber,
+        members: [reviewerProfile.id],
+        readers: [
+          CONFERENCE_ID + '/Program_Chairs',
+          CONFERENCE_ID + '/Paper' + paperNumber + '/Area_Chairs',
+          CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + nextAnonNumber],
+        writers: [
+          CONFERENCE_ID + '/Program_Chairs',
+          CONFERENCE_ID + '/Paper' + paperNumber + '/Area_Chairs'],
+        signatures: [CONFERENCE_ID + '/Paper' + paperNumber + '/Area_Chairs'],
+        signatories: [CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + nextAnonNumber]
+      })
+    })
+    .then(function(result) {
+      return Webfield.put('/groups/members', {
+        id: REVIEWER_GROUP,
+        members: [reviewerProfile.id]
+      })
+    })
+    .then(function(results) {
+      var forumUrl = 'https://openreview.net/forum?' + $.param({
+        id: paperForum,
+        invitationId: CONFERENCE_ID + '/-/Paper' + paperNumber + '/Official_Review'
+      });
+      var lastReminderSent = null;
+      reviewerSummaryMap[paperNumber].reviewers[nextAnonNumber] = {
+        id: reviewerProfile.id,
+        name: reviewerProfile.name,
+        email: reviewerProfile.email,
+        forum: paperForum,
+        forumUrl: forumUrl,
+        lastReminderSent: lastReminderSent,
+        paperNumber: paperNumber,
+        reviewerNumber: nextAnonNumber
+      };
+      reviewerSummaryMap[paperNumber].numReviewers = reviewerSummaryMap[paperNumber].numReviewers ? reviewerSummaryMap[paperNumber].numReviewers + 1 : 1;
+      reviewerSummaryMap[paperNumber].expandReviewerList = true;
+      reviewerSummaryMap[paperNumber].sendReminder = true;
+      reviewerSummaryMap[paperNumber].enableReviewerReassignment = ENABLE_REVIEWER_REASSIGNMENT;
+      var $revProgressDiv = $('#' + paperNumber + '-reviewer-progress');
+      $revProgressDiv.html(Handlebars.templates.noteReviewers(reviewerSummaryMap[paperNumber]));
+      updateReviewerContainer(paperNumber);
+      promptMessage('Email has been sent to ' + view.prettyId(reviewerProfile.id) + ' about their new assignment to paper ' + paperNumber);
+      var postData = {
+        groups: [reviewerProfile.id],
+        subject: SHORT_PHRASE + ": You have been assigned as a Reviewer for paper number " + paperNumber,
+        message: 'This is to inform you that you have been assigned as a Reviewer for paper number ' + paperNumber +
+        ' for ' + SHORT_PHRASE + '.' +
+        '\n\nTo review this new assignment, please login and click on ' +
+        'https://openreview.net/forum?id=' + paperForum + '&invitationId=' + getInvitationId(OFFICIAL_REVIEW_NAME, paperNumber.toString()) +
+        '\n\nTo check all of your assigned papers, please click on https://openreview.net/group?id=' + REVIEWER_GROUP +
+        '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair'
+      };
+      return Webfield.post('/mail', postData);
+    });
+    return false;
+  });
+
+  $('#group-container').on('click', 'a.unassign-reviewer-link', function(e) {
+    var $link = $(this);
+    var userId = $link.data('userId');
+    var paperNumber = $link.data('paperNumber');
+    var reviewerNumber = $link.data('reviewerNumber');
+
+    Webfield.delete('/groups/members', {
+      id: CONFERENCE_ID + '/Paper' + paperNumber + '/Reviewers',
+      members: [userId]
+    })
+    .then(function(result) {
+      return Webfield.delete('/groups/members', {
+        id: CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + reviewerNumber,
+        members: [userId]
+      });
+    })
+    .then(function(result) {
+      var $revProgressDiv = $('#' + paperNumber + '-reviewer-progress');
+      delete reviewerSummaryMap[paperNumber].reviewers[reviewerNumber];
+      reviewerSummaryMap[paperNumber].numReviewers = reviewerSummaryMap[paperNumber].numReviewers ? reviewerSummaryMap[paperNumber].numReviewers - 1 : 0;
+      reviewerSummaryMap[paperNumber].expandReviewerList = true;
+      $revProgressDiv.html(Handlebars.templates.noteReviewers(reviewerSummaryMap[paperNumber]));
+      updateReviewerContainer(paperNumber);
+      promptMessage('Reviewer ' + view.prettyId(userId) + ' has been unassigned for paper ' + paperNumber);
+    })
+    return false;
+  });
+
+  $('#group-container').on('change', '#select-all-papers', function(e) {
+    var $superCheckBox = $(this);
+    var $allPaperCheckBoxes = $('input.select-note-reviewers');
+    var $msgReviewerButton = $('#message-reviewers-btn');
+    if ($superCheckBox[0].checked === true) {
+      $allPaperCheckBoxes.prop("checked", true);
+      $msgReviewerButton.attr("disabled", false);
+    } else {
+      $allPaperCheckBoxes.prop("checked", false);
+      $msgReviewerButton.attr("disabled", true);
+    }
+  });
+
+  $('#group-container').on('change', 'input.select-note-reviewers', function(e) {
+    var $allPaperCheckBoxes = $('input.select-note-reviewers');
+    var $msgReviewerButton = $('#message-reviewers-btn');
+    var $superCheckBox = $('#select-all-papers');
+    var checkedBoxes = $allPaperCheckBoxes.filter(function(index) {
+      return $allPaperCheckBoxes[index].checked === true;
+    });
+    if (checkedBoxes.length) {
+      $msgReviewerButton.attr("disabled", false);
+      if (checkedBoxes.length === $allPaperCheckBoxes.length) {
+        $superCheckBox.prop("checked", true);
+      } else {
+        $superCheckBox.prop("checked", false);
+      }
+    } else {
+      $msgReviewerButton.attr("disabled", true);
+      $superCheckBox.prop("checked", false);
+    }
+  });
+};
+
+var postReviewerEmails = function(postData) {
+  postData.message = postData.message.replace(
+    '[[SUBMIT_REVIEW_LINK]]',
+    postData.forumUrl
+  );
+
+  return Webfield.post('/mail', postData)
+    .then(function(response) {
+      // Save the timestamp in the local storage
+      for (var i = 0; i < postData.groups.length; i++) {
+        var userId = postData.groups[i];
+        localStorage.setItem(postData.forumUrl + '|' + userId, Date.now());
+      }
+    });
+};
+
+main();

--- a/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
@@ -5,8 +5,7 @@ var SUBMISSION_ID = 'ICLR.cc/2020/Conference/-/Submission';
 var BLIND_SUBMISSION_ID = 'ICLR.cc/2020/Conference/-/Blind_Submission';
 var HEADER = {
   'title': 'Buddy Area Chairs Console',
-  'instructions': '<p class=\"dark\">This page provides information and status             updates for the Papers assigned to you in your role as a Buddy Area Chair for ICLR 2020.</p>',
-  'schedule': '<h4>Coming Soon</h4>            <p>                <em><strong>Please check back later for updates.</strong></em>            </p>'
+  'instructions': '<p class=\"dark\">This page provides information and status             updates for the Papers assigned to you in your role as a Buddy Area Chair for ICLR 2020.</p>'
 };
 var AREA_CHAIR_NAME = 'Area_Chairs';
 var BUDDY_AREA_CHAIR_NAME = 'Buddy_Area_Chairs';
@@ -35,7 +34,7 @@ var main = function() {
   })
   .then(loadData)
   .then(formatData)
-  .then(renderTableAndTasks)
+  .then(renderTable)
   .fail(function() {
     Webfield.ui.errorMessage();
   });
@@ -133,13 +132,6 @@ var loadData = function(result) {
     details: 'replytoNote,repliedNotes'
   });
 
-  var edgeInvitationsP = Webfield.getAll('/invitations', {
-    regex: WILDCARD_INVITATION,
-    invitee: true,
-    duedate: true,
-    type: 'edges'
-  });
-
   if (ENABLE_REVIEWER_REASSIGNMENT) {
     allReviewersP = Webfield.get('/groups', { id: REVIEWER_GROUP })
     .then(function(result) {
@@ -155,7 +147,6 @@ var loadData = function(result) {
     metaReviewsP,
     getReviewerGroups(noteNumbers),
     invitationsP,
-    edgeInvitationsP,
     allReviewersP
   );
 };
@@ -289,16 +280,6 @@ var renderHeader = function() {
       content: loadingMessage,
       extraClasses: 'horizontal-scroll',
       active: true
-    },
-    {
-      heading: 'Buddy AC Schedule',
-      id: 'areachair-schedule',
-      content: HEADER.schedule
-    },
-    {
-      heading: 'Buddy AC Tasks',
-      id: 'areachair-tasks',
-      content: loadingMessage
     }
   ]);
 };
@@ -602,27 +583,7 @@ var renderTableRows = function(rows, container) {
   }
 }
 
-var renderTasks = function(invitations, edgeInvitations) {
-  //  My Tasks tab
-  var tasksOptions = {
-    container: '#areachair-tasks',
-    emptyMessage: 'No outstanding tasks for this conference'
-  }
-  $(tasksOptions.container).empty();
-
-  // Filter out non-areachair tasks
-  var filterFunc = function(inv) {
-    return _.some(inv.invitees, function(invitee) { return invitee.indexOf(BUDDY_AREA_CHAIR_NAME) !== -1; });
-  };
-  var areachairInvitations = _.filter(invitations, filterFunc);
-  var areachairEdgeInvitations = _.filter(edgeInvitations, filterFunc);
-
-  Webfield.ui.newTaskList(areachairInvitations, areachairEdgeInvitations, tasksOptions);
-  $('.tabs-container a[href="#areachair-tasks"]').parent().show();
-}
-
-var renderTableAndTasks = function(fetchedData) {
-  renderTasks(fetchedData.invitations, fetchedData.edgeInvitations);
+var renderTable = function(fetchedData) {
 
   renderStatusTable(
     fetchedData.profiles,

--- a/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
@@ -570,7 +570,7 @@ var renderTableRows = function(rows, container) {
       return '<h4>Avg: ' + data.averageConfidence + '</h4><span>Min: ' + data.minConfidence + '</span>' +
         '<br><span>Max: ' + data.maxConfidence + '</span>';
     },
-    Handlebars.templates.noteMetaReviewStatusBuddy
+    Handlebars.templates.noteMetaReviewStatus
   ];
 
   var rowsHtml = rows.map(function(row) {
@@ -729,6 +729,7 @@ var buildTableRow = function(note, reviewerIds, completedReviews, metaReview) {
     invitationId: getInvitationId('Meta_Review', note.number)
   };
   var cell5 = {
+    isBuddyAC : true,
     invitationUrl: '/forum?' + $.param(invitationUrlParams)
   };
   if (metaReview) {

--- a/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
@@ -732,10 +732,7 @@ var buildTableRow = function(note, reviewerIds, completedReviews, metaReview) {
     noteId: note.id,
     invitationId: getInvitationId('Meta_Review', note.number)
   };
-  var cell5 = {
-    isBuddyAC : true,
-    invitationUrl: '/forum?' + $.param(invitationUrlParams)
-  };
+  var cell5 = {};
   if (metaReview) {
     cell5.recommendation = metaReview.content.recommendation;
     cell5.editUrl = '/forum?id=' + note.forum + '&noteId=' + metaReview.id;

--- a/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
@@ -125,16 +125,19 @@ var loadData = function(result) {
   }
 
   var invitationsP = Webfield.getAll('/invitations', {
-    regex: WILDCARD_INVITATION, invitee: true,
-    duedate: true, replyto: true, details: 'replytoNote,repliedNotes'
-  });
-
-  var tagInvitationsP = Webfield.getAll('/invitations', {
     regex: WILDCARD_INVITATION,
     invitee: true,
     duedate: true,
-    tags: true,
-    details:'repliedTags'
+    replyto: true,
+    type: 'notes',
+    details: 'replytoNote,repliedNotes'
+  });
+
+  var edgeInvitationsP = Webfield.getAll('/invitations', {
+    regex: WILDCARD_INVITATION,
+    invitee: true,
+    duedate: true,
+    type: 'edges'
   });
 
   if (ENABLE_REVIEWER_REASSIGNMENT) {
@@ -152,7 +155,7 @@ var loadData = function(result) {
     metaReviewsP,
     getReviewerGroups(noteNumbers),
     invitationsP,
-    tagInvitationsP,
+    edgeInvitationsP,
     allReviewersP
   );
 };
@@ -178,7 +181,7 @@ var getOfficialReviews = function(noteNumbers) {
           // Need to parse rating and confidence strings into ints
           ratingMatch = n.content.rating.match(ratingExp);
           n.rating = ratingMatch ? parseInt(ratingMatch[1], 10) : null;
-          confidenceMatch = n.content.confidence.match(ratingExp);
+          confidenceMatch = n.content.confidence && n.content.confidence.match(ratingExp);
           n.confidence = confidenceMatch ? parseInt(confidenceMatch[1], 10) : null;
 
           noteMap[num][index] = n;
@@ -213,7 +216,7 @@ var getReviewerGroups = function(noteNumbers) {
   });
 };
 
-var formatData = function(blindedNotes, officialReviews, metaReviews, noteToReviewerIds, invitations, tagInvitations, allReviewers) {
+var formatData = function(blindedNotes, officialReviews, metaReviews, noteToReviewerIds, invitations, edgeInvitations, allReviewers) {
   var uniqueIds = _.uniq(_.reduce(noteToReviewerIds, function(result, idsObj, noteNum) {
     return result.concat(_.values(idsObj));
   }, []));
@@ -227,7 +230,7 @@ var formatData = function(blindedNotes, officialReviews, metaReviews, noteToRevi
       metaReviews: metaReviews,
       noteToReviewerIds: noteToReviewerIds,
       invitations: invitations,
-      tagInvitations: tagInvitations
+      edgeInvitations: edgeInvitations
     };
   });
 };
@@ -599,7 +602,7 @@ var renderTableRows = function(rows, container) {
   }
 }
 
-var renderTasks = function(invitations, tagInvitations) {
+var renderTasks = function(invitations, edgeInvitations) {
   //  My Tasks tab
   var tasksOptions = {
     container: '#areachair-tasks',
@@ -612,14 +615,14 @@ var renderTasks = function(invitations, tagInvitations) {
     return _.some(inv.invitees, function(invitee) { return invitee.indexOf(BUDDY_AREA_CHAIR_NAME) !== -1; });
   };
   var areachairInvitations = _.filter(invitations, filterFunc);
-  var areachairTagInvitations = _.filter(tagInvitations, filterFunc);
+  var areachairEdgeInvitations = _.filter(edgeInvitations, filterFunc);
 
-  Webfield.ui.newTaskList(areachairInvitations, areachairTagInvitations, tasksOptions);
+  Webfield.ui.newTaskList(areachairInvitations, areachairEdgeInvitations, tasksOptions);
   $('.tabs-container a[href="#areachair-tasks"]').parent().show();
 }
 
 var renderTableAndTasks = function(fetchedData) {
-  renderTasks(fetchedData.invitations, fetchedData.tagInvitations);
+  renderTasks(fetchedData.invitations, fetchedData.edgeInvitations);
 
   renderStatusTable(
     fetchedData.profiles,

--- a/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
@@ -3,7 +3,11 @@ var CONFERENCE_ID = 'ICLR.cc/2020/Conference';
 var SHORT_PHRASE = 'ICLR 2020';
 var SUBMISSION_ID = 'ICLR.cc/2020/Conference/-/Submission';
 var BLIND_SUBMISSION_ID = 'ICLR.cc/2020/Conference/-/Blind_Submission';
-var HEADER = {"title": "Buddy Area Chairs Console", "instructions": "<p class=\"dark\">This page provides information and status             updates for the Papers assigned to you in your role as a Buddy Area Chair for ICLR 2020.</p>", "schedule": "<h4>Coming Soon</h4>            <p>                <em><strong>Please check back later for updates.</strong></em>            </p>"};
+var HEADER = {
+  'title': 'Buddy Area Chairs Console',
+  'instructions': '<p class=\"dark\">This page provides information and status             updates for the Papers assigned to you in your role as a Buddy Area Chair for ICLR 2020.</p>',
+  'schedule': '<h4>Coming Soon</h4>            <p>                <em><strong>Please check back later for updates.</strong></em>            </p>'
+};
 var AREA_CHAIR_NAME = 'Area_Chairs';
 var BUDDY_AREA_CHAIR_NAME = 'Buddy_Area_Chairs';
 var REVIEWER_NAME = 'Reviewers';
@@ -336,7 +340,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
   var sendReviewerReminderEmailsStep1 = function(e) {
     var subject = $('#message-reviewers-modal input[name="subject"]').val().trim();
     var message = $('#message-reviewers-modal textarea[name="message"]').val().trim();
-    var filter  = $(this)[0].dataset["filter"];
+    var filter  = $(this)[0].dataset['filter'];
 
     var count = 0;
     var selectedRows = rows;
@@ -461,12 +465,12 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
     return false;
   });
 
-  $('#div-msg-reviewers').find("a").on('click', function(e) {
+  $('#div-msg-reviewers').find('a').on('click', function(e) {
     var filter = $(this)[0].id;
     $('#message-reviewers-modal').remove();
 
-    var defaultBody = "";
-    if (filter === "msg-unsubmitted-reviewers"){
+    var defaultBody = '';
+    if (filter === 'msg-unsubmitted-reviewers'){
       defaultBody = 'This is a reminder to please submit your review for ' + SHORT_PHRASE + '. ' +
       'Click on the link below to go to the review page:\n\n[[SUBMIT_REVIEW_LINK]]' +
       '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair';
@@ -741,7 +745,7 @@ var buildTableRow = function(note, reviewerIds, completedReviews, metaReview) {
 };
 
 var findNextAnonGroupNumber = function(paperNumber){
-  paperReviewerNums = Object.keys(reviewerSummaryMap[paperNumber].reviewers).sort();
+  var paperReviewerNums = Object.keys(reviewerSummaryMap[paperNumber].reviewers).sort();
   for (var i = 1; i < paperReviewerNums.length + 1; i++) {
     if (i.toString() !== paperReviewerNums[i-1]) {
       return i;
@@ -773,7 +777,7 @@ var registerEventHandlers = function() {
       };
 
       $('#message-reviewers-modal').modal('hide');
-      // promptMessage('Your reminder email has been sent to ' + view.prettyId(userId));
+      promptMessage('A reminder email has been sent to ' + view.prettyId(userId));
       postReviewerEmails(postData);
       $link.after(' (Last sent: ' + (new Date()).toLocaleDateString() + ')');
 
@@ -891,7 +895,7 @@ var registerEventHandlers = function() {
       promptMessage('Email has been sent to ' + view.prettyId(reviewerProfile.id) + ' about their new assignment to paper ' + paperNumber);
       var postData = {
         groups: [reviewerProfile.id],
-        subject: SHORT_PHRASE + ": You have been assigned as a Reviewer for paper number " + paperNumber,
+        subject: SHORT_PHRASE + ': You have been assigned as a Reviewer for paper number ' + paperNumber,
         message: 'This is to inform you that you have been assigned as a Reviewer for paper number ' + paperNumber +
         ' for ' + SHORT_PHRASE + '.' +
         '\n\nTo review this new assignment, please login and click on ' +
@@ -937,11 +941,11 @@ var registerEventHandlers = function() {
     var $allPaperCheckBoxes = $('input.select-note-reviewers');
     var $msgReviewerButton = $('#message-reviewers-btn');
     if ($superCheckBox[0].checked === true) {
-      $allPaperCheckBoxes.prop("checked", true);
-      $msgReviewerButton.attr("disabled", false);
+      $allPaperCheckBoxes.prop('checked', true);
+      $msgReviewerButton.attr('disabled', false);
     } else {
-      $allPaperCheckBoxes.prop("checked", false);
-      $msgReviewerButton.attr("disabled", true);
+      $allPaperCheckBoxes.prop('checked', false);
+      $msgReviewerButton.attr('disabled', true);
     }
   });
 
@@ -953,15 +957,15 @@ var registerEventHandlers = function() {
       return $allPaperCheckBoxes[index].checked === true;
     });
     if (checkedBoxes.length) {
-      $msgReviewerButton.attr("disabled", false);
+      $msgReviewerButton.attr('disabled', false);
       if (checkedBoxes.length === $allPaperCheckBoxes.length) {
-        $superCheckBox.prop("checked", true);
+        $superCheckBox.prop('checked', true);
       } else {
-        $superCheckBox.prop("checked", false);
+        $superCheckBox.prop('checked', false);
       }
     } else {
-      $msgReviewerButton.attr("disabled", true);
-      $superCheckBox.prop("checked", false);
+      $msgReviewerButton.attr('disabled', true);
+      $superCheckBox.prop('checked', false);
     }
   });
 };

--- a/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
+++ b/venues/ICLR.cc/2020/Conference/python/buddyAreachairWebfield.js
@@ -471,13 +471,10 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
 
     var defaultBody = '';
     if (filter === 'msg-unsubmitted-reviewers'){
-      defaultBody = 'This is a reminder to please submit your review for ' + SHORT_PHRASE + '. ' +
-      'Click on the link below to go to the review page:\n\n[[SUBMIT_REVIEW_LINK]]' +
-      '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair';
-    } else {
-      defaultBody = 'Click on the link below to go to the review page:\n\n[[SUBMIT_REVIEW_LINK]]' +
-      '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair';
+      defaultBody = 'This is a reminder to please submit your review for ' + SHORT_PHRASE + '.\n\n';
     }
+    defaultBody += 'Click on the link below to go to the review page:\n\n[[SUBMIT_REVIEW_LINK]]' +
+    '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair';
 
     var modalHtml = Handlebars.templates.messageReviewersModalFewerOptions({
       filter: filter,
@@ -786,7 +783,7 @@ var registerEventHandlers = function() {
       reviewerId: userId,
       forumUrl: forumUrl,
       defaultSubject: SHORT_PHRASE + ' Reminder',
-      defaultBody: 'This is a reminder to please submit your review for ' + SHORT_PHRASE + '. ' +
+      defaultBody: 'This is a reminder to please submit your review for ' + SHORT_PHRASE + '.\n\n' +
         'Click on the link below to go to the review page:\n\n[[SUBMIT_REVIEW_LINK]]' +
         '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair',
     });
@@ -849,11 +846,14 @@ var registerEventHandlers = function() {
       return Webfield.post('/groups', {
         id: CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + nextAnonNumber,
         members: [reviewerProfile.id],
+        nonreaders: [CONFERENCE_ID + '/Paper' + paperNumber + '/Authors'],
         readers: [
+          CONFERENCE_ID,
           CONFERENCE_ID + '/Program_Chairs',
           CONFERENCE_ID + '/Paper' + paperNumber + '/Area_Chairs',
           CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + nextAnonNumber],
         writers: [
+          CONFERENCE_ID,
           CONFERENCE_ID + '/Program_Chairs',
           CONFERENCE_ID + '/Paper' + paperNumber + '/Area_Chairs'],
         signatures: [CONFERENCE_ID + '/Paper' + paperNumber + '/Area_Chairs'],
@@ -913,12 +913,12 @@ var registerEventHandlers = function() {
 
     Webfield.delete('/groups/members', {
       id: CONFERENCE_ID + '/Paper' + paperNumber + '/Reviewers',
-      members: [userId]
+      members: [reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].id, reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].email]
     })
     .then(function(result) {
       return Webfield.delete('/groups/members', {
         id: CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + reviewerNumber,
-        members: [userId]
+        members: [reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].id, reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].email]
       });
     })
     .then(function(result) {

--- a/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
+++ b/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
@@ -1,0 +1,114 @@
+import openreview
+import argparse
+import datetime
+
+buddy_ac_parent_group_name = 'Buddy_Area_Chairs'
+buddy_ac_individual_group_name = 'Buddy_Area_Chair1'
+
+# def update_homepage():
+
+if __name__ == '__main__':
+    ## Argument handling
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--baseurl', help="base url")
+    parser.add_argument('--username')
+    parser.add_argument('--password')
+    args = parser.parse_args()
+
+    client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+    conference = openreview.helpers.get_conference(client, 'SkxpQPWdA4')
+
+    # update_homepage(conference)
+
+    conference_id = conference.get_id()
+    ac_group = client.get_group(conference.get_area_chairs_id())
+
+    buddy_ac_group = client.post_group(
+        openreview.Group(
+            id = conference_id + '/' + buddy_ac_parent_group_name,
+            readers = [
+                conference_id,
+                conference.get_program_chairs_id(),
+                conference.get_area_chairs_id()],
+            signatories = [conference_id + '/' + buddy_ac_parent_group_name],
+            signatures = [conference.get_id()],
+            writers = [conference.get_id()],
+            web = 'buddyAreachairWebfield.js',
+            members = ac_group.members
+        )
+    )
+
+    submissions = conference.get_submissions()
+    for paper in submissions:
+        paper_number = str(paper.number)
+        individual_group_id = conference_id + '/Paper' + paper_number + '/' + buddy_ac_individual_group_name
+        print (individual_group_id)
+        individual_buddy_group = client.post_group(
+            openreview.Group(
+                id = individual_group_id,
+                readers = [
+                    conference_id,
+                    conference.get_program_chairs_id(),
+                    individual_group_id],
+                nonreaders = [conference_id + '/Paper' + paper_number + '/Authors'],
+                signatories = [individual_group_id],
+                signatures = [conference.get_id()],
+                writers = [conference.get_id()],
+                members = ['~Mohit_Uniyal1']
+            )
+        )
+
+        ac_conversation_invitation = openreview.Invitation(
+            id = conference_id + '/Paper' + paper_number + '/-/Area_Chair_Only_Comment',
+            # super = 'ICLR.cc/2020/Conference/-/Area_Chair_Internal_Comment',
+            readers = ['everyone'],
+            writers = [conference_id],
+            signatures = [conference_id],
+            invitees = [
+                conference.get_area_chairs_id(number = paper_number), individual_group_id
+            ],
+            reply = {
+                "forum" : paper.forum,
+                "readers": {
+                    "description": "Select all user groups that should be able to read this comment.",
+                    "values": [
+                        "ICLR.cc/2020/Conference/Paper" + paper_number + "/Area_Chairs",
+                        "ICLR.cc/2020/Conference/Paper" + paper_number + "/Buddy_Area_Chair1",
+                        conference.get_program_chairs_id()
+                    ]
+                    },
+                "writers": {
+                    "values-regex": "ICLR.cc/2020/Conference/Paper6/(Buddy_)*Area_Chair[0-9]+",
+                    "description": "How your identity will be displayed."
+                },
+                "signatures": {
+                    "values-regex": "ICLR.cc/2020/Conference/Paper6/(Buddy_)*Area_Chair[0-9]+",
+                    "description": "How your identity will be displayed."
+                },
+                "content": {
+                    "comment": {
+                        "value-regex": "[\\S\\s]{1,5000}",
+                        "required": True,
+                        "order": 1,
+                        "description": "Your comment or reply (max 5000 characters)."
+                    },
+                    "title": {
+                        "value-regex": ".{1,500}",
+                        "required": True,
+                        "order": 0,
+                        "description": "Brief summary of your comment."
+                    }
+                }
+            },
+            process = 'buddyAcCommentProcess.js'
+        )
+        client.post_invitation(ac_conversation_invitation)
+
+    all_anon_revs = openreview.tools.iterget_groups(client, regex = 'ICLR.cc/2020/Conference/Paper[0-9]+/AnonReviewer[0-9]+')
+    for anon_rev in all_anon_revs:
+        paper_number = str(anon_rev.id.split('Paper')[1].split('/')[0])
+        individual_group_id = conference_id + '/Paper' + paper_number + '/' + buddy_ac_individual_group_name
+        if individual_group_id not in anon_rev.readers:
+            anon_rev.readers.append(individual_group_id)
+
+        upd_anon = client.post_group(anon_rev)

--- a/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
+++ b/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
@@ -92,55 +92,45 @@ if __name__ == '__main__':
             id = conference_id + '/Paper' + paper_number + '/-/Area_Chair_Only_Comment',
             readers = [
                 conference.get_area_chairs_id(number = paper_number),
-                individual_buddy_group_id,
                 conference_id
             ],
             writers = [conference_id],
             signatures = [conference_id],
             invitees = [
-                conference.get_area_chairs_id(number = paper_number), individual_buddy_group_id
+                conference.get_area_chairs_id(number = paper_number)
             ],
             reply = {
-                "forum" : paper.forum,
-                "readers": {
-                    "description": "Select all user groups that should be able to read this comment.",
-                    "values": [
-                        "ICLR.cc/2020/Conference/Paper" + paper_number + "/Area_Chairs",
-                        "ICLR.cc/2020/Conference/Paper" + paper_number + "/Buddy_Area_Chair1",
+                'forum' : paper.forum,
+                'readers': {
+                    'description': 'Select all user groups that should be able to read this comment.',
+                    'values': [
+                        conference.get_area_chairs_id(number = paper_number),
                         conference.get_program_chairs_id()
                     ]
                     },
-                "writers": {
-                    "values-regex": "ICLR.cc/2020/Conference/Paper6/(Buddy_)*Area_Chair[0-9]+",
-                    "description": "How your identity will be displayed."
+                'writers': {
+                    'values-regex': conference_id + '/Paper' + + '/(Buddy_)*Area_Chair[0-9]+',
+                    'description': 'How your identity will be displayed.'
                 },
-                "signatures": {
-                    "values-regex": "ICLR.cc/2020/Conference/Paper6/(Buddy_)*Area_Chair[0-9]+",
-                    "description": "How your identity will be displayed."
+                'signatures': {
+                    'values-regex': conference_id + '/Paper6/(Buddy_)*Area_Chair[0-9]+',
+                    'description': 'How your identity will be displayed.'
                 },
-                "content": {
-                    "comment": {
-                        "value-regex": "[\\S\\s]{1,5000}",
-                        "required": True,
-                        "order": 1,
-                        "description": "Your comment or reply (max 5000 characters)."
+                'content': {
+                    'comment': {
+                        'value-regex': '[\\S\\s]{1,5000}',
+                        'required': True,
+                        'order': 1,
+                        'description': 'Your comment or reply (max 5000 characters).'
                     },
-                    "title": {
-                        "value-regex": ".{1,500}",
-                        "required": True,
-                        "order": 0,
-                        "description": "Brief summary of your comment."
+                    'title': {
+                        'value-regex': '.{1,500}',
+                        'required': True,
+                        'order': 0,
+                        'description': 'Brief summary of your comment.'
                     }
                 }
             },
             process = 'buddyAcCommentProcess.js'
         )
         client.post_invitation(ac_conversation_invitation)
-
-    all_anon_revs = openreview.tools.iterget_groups(client, regex = 'ICLR.cc/2020/Conference/Paper[0-9]+/AnonReviewer[0-9]+')
-    for anon_rev in all_anon_revs:
-        paper_number = str(anon_rev.id.split('Paper')[1].split('/')[0])
-        individual_buddy_group_id = conference_id + '/Paper' + paper_number + '/' + buddy_ac_individual_group_name
-        if individual_buddy_group_id not in anon_rev.readers:
-            anon_rev.readers.append(individual_buddy_group_id)
-        upd_anon = client.post_group(anon_rev)

--- a/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
+++ b/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     if not buddy_ac_parent_group:
         ac_group = client.get_group(conference.get_area_chairs_id())
 
-        buddy_ac_group = client.post_group(
+        print('Posted ', client.post_group(
             openreview.Group(
                 id = conference_id + '/' + buddy_ac_parent_group_name,
                 readers = [
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                 web = 'buddyAreachairWebfield.js',
                 members = ac_group.members
             )
-        )
+        ).id)
 
     map_meta_review_invitations = {invitation.id.split('Paper')[1].split('/')[0]: invitation for invitation in openreview.tools.iterget_invitations(client, regex = conference_id + '/Paper[0-9]+/-/Meta_Review')}
 
@@ -56,21 +56,20 @@ if __name__ == '__main__':
 
         ## Create buddy ac group for this paper
         if paper_number not in map_paper_buddy_ac_groups:
-            individual_buddy_group = client.post_group(
+            print('Posted ', client.post_group(
                 openreview.Group(
                     id = individual_buddy_group_id,
                     readers = [
                         conference_id,
                         conference.get_program_chairs_id(),
-                        conference.get_area_chairs_id(paper_number),
-                        individual_buddy_group_id],
+                        conference.get_area_chairs_id(paper_number)],
                     nonreaders = [conference_id + '/Paper' + paper_number + '/Authors'],
                     signatories = [individual_buddy_group_id],
                     signatures = [conference.get_id()],
                     writers = [conference.get_id()],
                     members = []
                 )
-            )
+            ).id)
 
         paper_ac_individual_group = map_paper_ac_individual_groups.get(paper_number)
         if paper_ac_individual_group and (individual_buddy_group_id not in paper_ac_individual_group.readers):
@@ -113,7 +112,7 @@ if __name__ == '__main__':
                     'description': 'How your identity will be displayed.'
                 },
                 'signatures': {
-                    'values-regex': conference_id + '/Paper6/(Buddy_)*Area_Chair[0-9]+',
+                    'values-regex': conference_id + '/Paper' + paper_number + '/(Buddy_)*Area_Chair[0-9]+',
                     'description': 'How your identity will be displayed.'
                 },
                 'content': {

--- a/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
+++ b/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
@@ -43,7 +43,11 @@ if __name__ == '__main__':
 
     map_meta_review_invitations = {invitation.id.split('Paper')[1].split('/')[0]: invitation for invitation in openreview.tools.iterget_invitations(client, regex = conference_id + '/Paper[0-9]+/-/Meta_Review')}
 
-    map_paper_ac_groups = {group.id.split('Paper')[1].split('/')[0]: group for group in openreview.tools.iterget_groups(client, regex = conference_id + '/Paper[0-9]+/Area_Chairs$')}
+    map_paper_ac_parent_groups = {group.id.split('Paper')[1].split('/')[0]: group for group in openreview.tools.iterget_groups(client, regex = conference_id + '/Paper[0-9]+/Area_Chairs$')}
+
+    map_paper_ac_individual_groups = {group.id.split('Paper')[1].split('/')[0]: group for group in openreview.tools.iterget_groups(client, regex = conference_id + '/Paper[0-9]+/Area_Chair1$')}
+
+    map_paper_buddy_ac_groups = {group.id.split('Paper')[1].split('/')[0]: group for group in openreview.tools.iterget_groups(client, regex = conference_id + '/Paper[0-9]+/' + buddy_ac_individual_group_name + '$')}
 
     submissions = conference.get_submissions()
     for paper in submissions:
@@ -51,29 +55,36 @@ if __name__ == '__main__':
         individual_buddy_group_id = conference_id + '/Paper' + paper_number + '/' + buddy_ac_individual_group_name
 
         ## Create buddy ac group for this paper
-        individual_buddy_group = client.post_group(
-            openreview.Group(
-                id = individual_buddy_group_id,
-                readers = [
-                    conference_id,
-                    conference.get_program_chairs_id(),
-                    individual_buddy_group_id],
-                nonreaders = [conference_id + '/Paper' + paper_number + '/Authors'],
-                signatories = [individual_buddy_group_id],
-                signatures = [conference.get_id()],
-                writers = [conference.get_id()],
-                members = []
+        if paper_number not in map_paper_buddy_ac_groups:
+            individual_buddy_group = client.post_group(
+                openreview.Group(
+                    id = individual_buddy_group_id,
+                    readers = [
+                        conference_id,
+                        conference.get_program_chairs_id(),
+                        conference.get_area_chairs_id(paper_number),
+                        individual_buddy_group_id],
+                    nonreaders = [conference_id + '/Paper' + paper_number + '/Authors'],
+                    signatories = [individual_buddy_group_id],
+                    signatures = [conference.get_id()],
+                    writers = [conference.get_id()],
+                    members = []
+                )
             )
-        )
 
-        # Add paper's buddy AC as member to paper's AC group
-        paper_ac_group = map_paper_ac_groups[paper_number]
-        client.add_members_to_group(paper_ac_group, individual_buddy_group_id)
+        paper_ac_individual_group = map_paper_ac_individual_groups.get(paper_number)
+        if paper_ac_individual_group and (individual_buddy_group_id not in paper_ac_individual_group.readers):
+            paper_ac_individual_group.readers.append(individual_buddy_group_id)
+            client.post_group(paper_ac_individual_group)
+
+        # Add paper's buddy AC as member to paper's AC parent group
+        paper_ac_parent_group = map_paper_ac_parent_groups[paper_number]
+        client.add_members_to_group(paper_ac_parent_group, individual_buddy_group_id)
 
         # Add paper's buddy AC as non-invitee for paper's meta-review invitation
         paper_meta_rev_invitation = map_meta_review_invitations.get(paper_number, None)
         if (paper_meta_rev_invitation):
-            paper_meta_rev_invitation.noninvitees = individual_buddy_group_id
+            paper_meta_rev_invitation.noninvitees = [individual_buddy_group_id]
             client.post_invitation(paper_meta_rev_invitation)
 
         ## Post AC & AC-Buddy only Comment invitation for this paper

--- a/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
+++ b/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
@@ -89,7 +89,6 @@ if __name__ == '__main__':
             client.post_invitation(paper_meta_rev_invitation)
 
         ## Update Official Comment invitation for this paper
-        for paper_number in map_paper_to_official_comment_invitations:
-            official_comment_invitation = map_paper_to_official_comment_invitations[paper_number]
-            official_comment_invitation.reply['signatures']['values-regex'] += '|' + conference.get_id() + '/Paper' + paper_number + '/' + buddy_ac_individual_group_name
-            client.post_invitation(official_comment_invitation)
+        official_comment_invitation = map_paper_to_official_comment_invitations[paper_number]
+        official_comment_invitation.reply['signatures']['values-regex'] += '|' + conference.get_id() + '/Paper' + paper_number + '/' + buddy_ac_individual_group_name
+        client.post_invitation(official_comment_invitation)

--- a/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
+++ b/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
@@ -108,11 +108,11 @@ if __name__ == '__main__':
                     ]
                     },
                 'writers': {
-                    'values-regex': conference_id + '/Paper' + paper_number + '/(Buddy_)*Area_Chair[0-9]+',
+                    'values-regex': conference_id + '/Paper' + paper_number + '/(Buddy_)*Area_Chair[0-9]+$',
                     'description': 'How your identity will be displayed.'
                 },
                 'signatures': {
-                    'values-regex': conference_id + '/Paper' + paper_number + '/(Buddy_)*Area_Chair[0-9]+',
+                    'values-regex': conference_id + '/Paper' + paper_number + '/(Buddy_)*Area_Chair[0-9]+$',
                     'description': 'How your identity will be displayed.'
                 },
                 'content': {

--- a/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
+++ b/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
@@ -71,8 +71,10 @@ if __name__ == '__main__':
         client.add_members_to_group(paper_ac_group, individual_buddy_group_id)
 
         # Add paper's buddy AC as non-invitee for paper's meta-review invitation
-        paper_meta_rev_invitation = map_meta_review_invitations[paper_number]
-        paper_meta_rev_invitation.noninvitees
+        paper_meta_rev_invitation = map_meta_review_invitations.get(paper_number, None)
+        if (paper_meta_rev_invitation):
+            paper_meta_rev_invitation.noninvitees = individual_buddy_group_id
+            client.post_invitation(paper_meta_rev_invitation)
 
         ## Post AC & AC-Buddy only Comment invitation for this paper
         ac_conversation_invitation = openreview.Invitation(

--- a/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
+++ b/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
                 signatories = [individual_buddy_group_id],
                 signatures = [conference.get_id()],
                 writers = [conference.get_id()],
-                members = ['~Mohit_Uniyal1']
+                members = []
             )
         )
 

--- a/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
+++ b/venues/ICLR.cc/2020/Conference/python/buddy_ac.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
                     ]
                     },
                 'writers': {
-                    'values-regex': conference_id + '/Paper' + + '/(Buddy_)*Area_Chair[0-9]+',
+                    'values-regex': conference_id + '/Paper' + paper_number + '/(Buddy_)*Area_Chair[0-9]+',
                     'description': 'How your identity will be displayed.'
                 },
                 'signatures': {


### PR DESCRIPTION
buddy_ac.py adds a per paper buddy_ac group. We can later add a member to each of these groups. These groups get added as members of Paper AC groups and thus can see everything the AC see. 
The script then adds these buddy ac groups as non-invitees of the meta-review invitation to make sure that they do not post meta-reviews.

Also, we use a difference webfield for the buddy ac group, as specified by the file buddyAreaChairWebfield.js.
The script also posts an invitation for enabling AC and Buddy AC communication. The invitation is called "Area_Chair_Only_Comment" and I am open to suggestions on renaming this.
This invitation uses the processFunction described in buddyAcCommentProcess.js.

Requires :
1. https://github.com/iesl/openreview-py/pull/403
2. https://github.com/iesl/openreview/pull/1567