### PR TITLE
Support notification tags for comments

### DIFF
--- a/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/process/commentProcess.py
+++ b/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/process/commentProcess.py
@@ -1,0 +1,52 @@
+def process(client, note, invitation):
+    SHORT_PHRASE = "NeurIPS Reproducibility Challenge"
+    # get all notification tags for this paper
+    notify_inv = invitation.id.replace('Comment', 'Notification')
+    # TODO change to iterget
+    notifications = client.get_tags(invitation=notify_inv)
+
+    email_list = []
+    all_notifiers = []
+    for tag in notifications:
+        if tag.tag == 'Immediate':
+            email_list.append(tag.signatures[0])
+        all_notifiers.append(tag.signatures[0])
+
+    # get submission author and add to email list if author hasn't set a notification tag
+    forumNote = client.get_note(id=note.forum)
+    profile = None
+    # if there is a primary author id, and it is not on the list already, add it
+    if forumNote.content['authorids'][0]:
+        try:
+            if forumNote.content['authorids'][0]:
+                profile = client.get_profile(forumNote.content['authorids'][0])
+        except openreview.OpenReviewException as e:
+            # throw an error if it is something other than "not found"
+            if e.args[0][0] != 'Profile not found':
+                raise e
+        if profile:
+            # if submission author not in list, then add to immediate
+            print("Profile ID: "+profile.id)
+            if profile.id not in all_notifiers and profile.id not in email_list:
+                email_list.append(profile.id)
+        else:
+            # if submission author doesn't have profile, add email to email_list
+            email_list.append(forumNote.content['authorids'][0])
+
+    if email_list:
+        # send email to those in the immediate notification group
+        subject = '[' + SHORT_PHRASE + '] Paper Title: "' + forumNote.content['title'] + '" received a comment'
+        formatted_msg = 'The NeurIPS submission titled "' + forumNote.content['title'] + '" has received a comment.\n\nComment title: ' \
+                        + note.content['title'] + '\n\nComment: ' + note.content['comment'] + '\n\nTo view the comment, click here: ' + \
+                        client.baseurl + '/forum?id=' + note.forum + '&noteId=' + note.id + '\n\nIf you do not wish to receive notifications for comments on this paper, visit the link above and change the Notification frequency.'
+
+        response = client.send_mail(subject, email_list, formatted_msg)
+
+    # if comment author is not the paper author and doesn't have notifications set up,
+    # send email on how to set notifications
+    if profile and (note.signatures[0] != profile.id) and (note.signatures[0] not in all_notifiers):
+        print("comment author needs instructions")
+        subject = '[' + SHORT_PHRASE + '] Paper Title: "' + forumNote.content['title'] + '" received your comment'
+        message = "If you wish to receive email when people comment on this paper, go to "+client.baseurl + '/forum?id=' + note.forum + \
+            " and select the Notification frequency."
+        response = client.send_mail(subject, [note.signatures[0]], message)

--- a/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/process/commentProcess.py
+++ b/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/process/commentProcess.py
@@ -1,9 +1,7 @@
 def process(client, note, invitation):
     SHORT_PHRASE = "NeurIPS Reproducibility Challenge"
     # get all notification tags for this paper
-    notify_inv = invitation.id.replace('Comment', 'Notification_Subscription')
-    # TODO change to iterget
-    notifications = client.get_tags(invitation=notify_inv)
+    notifications = client.get_tags(forum=note.forum)
 
     email_list = [tag.signatures[0] for tag in notifications if tag.tag == 'Immediate']
     all_notifiers = [tag.signatures[0] for tag in notifications]

--- a/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/process/commentProcess.py
+++ b/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/process/commentProcess.py
@@ -1,34 +1,25 @@
 def process(client, note, invitation):
     SHORT_PHRASE = "NeurIPS Reproducibility Challenge"
     # get all notification tags for this paper
-    notify_inv = invitation.id.replace('Comment', 'Comment_Notification')
+    notify_inv = invitation.id.replace('Comment', 'Notification_Subscription')
     # TODO change to iterget
     notifications = client.get_tags(invitation=notify_inv)
 
-    email_list = []
-    all_notifiers = []
-    for tag in notifications:
-        if tag.tag == 'Immediate':
-            email_list.append(tag.signatures[0])
-        all_notifiers.append(tag.signatures[0])
+    email_list = [tag.signatures[0] for tag in notifications if tag.tag == 'Immediate']
+    all_notifiers = [tag.signatures[0] for tag in notifications]
 
     # get submission author and add to email list if author hasn't set a notification tag
     forumNote = client.get_note(id=note.forum)
+
+    # add comment author to email list if does not have a tag
+    if note.signatures[0] and note.signatures[0] not in all_notifiers:
+        email_list.append[note.signatures[0]]
 
     if email_list:
         # send email to those in the immediate notification group
         subject = '[' + SHORT_PHRASE + '] Paper Title: "' + forumNote.content['title'] + '" received a comment'
         formatted_msg = 'The NeurIPS submission titled "' + forumNote.content['title'] + '" has received a comment.\n\nComment title: ' \
                         + note.content['title'] + '\n\nComment: ' + note.content['comment'] + '\n\nTo view the comment, click here: ' + \
-                        client.baseurl + '/forum?id=' + note.forum + '&noteId=' + note.id + '\n\nIf you do not wish to receive notifications for comments on this paper, visit the link above and change the Notification frequency.'
+                        client.baseurl + '/forum?id=' + note.forum + '&noteId=' + note.id + '\n\nIf you wish to change your email notification preferences for comments on this paper, log into OpenReview.net, visit the link above and change the Notification Subscription frequency.'
 
         response = client.send_mail(subject, email_list, formatted_msg)
-
-    # if comment author doesn't have notifications set up,
-    # send email on how to set notifications
-    if note.signatures[0] not in all_notifiers:
-        print("comment author needs instructions")
-        subject = '[' + SHORT_PHRASE + '] Paper Title: "' + forumNote.content['title'] + '" received your comment'
-        message = "If you wish to receive email when people comment on this paper, go to "+client.baseurl + '/forum?id=' + note.forum + \
-            " and select the Comment Notification frequency."
-        response = client.send_mail(subject, [note.signatures[0]], message)

--- a/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/process/commentProcess.py
+++ b/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/process/commentProcess.py
@@ -1,7 +1,7 @@
 def process(client, note, invitation):
     SHORT_PHRASE = "NeurIPS Reproducibility Challenge"
     # get all notification tags for this paper
-    notify_inv = invitation.id.replace('Comment', 'Notification')
+    notify_inv = invitation.id.replace('Comment', 'Comment_Notification')
     # TODO change to iterget
     notifications = client.get_tags(invitation=notify_inv)
 
@@ -14,24 +14,6 @@ def process(client, note, invitation):
 
     # get submission author and add to email list if author hasn't set a notification tag
     forumNote = client.get_note(id=note.forum)
-    profile = None
-    # if there is a primary author id, and it is not on the list already, add it
-    if forumNote.content['authorids'][0]:
-        try:
-            if forumNote.content['authorids'][0]:
-                profile = client.get_profile(forumNote.content['authorids'][0])
-        except openreview.OpenReviewException as e:
-            # throw an error if it is something other than "not found"
-            if e.args[0][0] != 'Profile not found':
-                raise e
-        if profile:
-            # if submission author not in list, then add to immediate
-            print("Profile ID: "+profile.id)
-            if profile.id not in all_notifiers and profile.id not in email_list:
-                email_list.append(profile.id)
-        else:
-            # if submission author doesn't have profile, add email to email_list
-            email_list.append(forumNote.content['authorids'][0])
 
     if email_list:
         # send email to those in the immediate notification group
@@ -42,11 +24,11 @@ def process(client, note, invitation):
 
         response = client.send_mail(subject, email_list, formatted_msg)
 
-    # if comment author is not the paper author and doesn't have notifications set up,
+    # if comment author doesn't have notifications set up,
     # send email on how to set notifications
-    if profile and (note.signatures[0] != profile.id) and (note.signatures[0] not in all_notifiers):
+    if note.signatures[0] not in all_notifiers:
         print("comment author needs instructions")
         subject = '[' + SHORT_PHRASE + '] Paper Title: "' + forumNote.content['title'] + '" received your comment'
         message = "If you wish to receive email when people comment on this paper, go to "+client.baseurl + '/forum?id=' + note.forum + \
-            " and select the Notification frequency."
+            " and select the Comment Notification frequency."
         response = client.send_mail(subject, [note.signatures[0]], message)

--- a/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/python/comment_notification.py
+++ b/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/python/comment_notification.py
@@ -1,0 +1,102 @@
+
+import argparse
+import openreview
+from openreview import tools
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base url")
+parser.add_argument('--username')
+parser.add_argument('--password')
+args = parser.parse_args()
+
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+print("Connected to "+client.baseurl)
+conference_id = 'NeurIPS.cc/2019/Reproducibility_Challenge'
+
+# for each submission, create group (so sub invites can be published)
+# create invitation for notification frequency tags
+# create invite for comment
+notes = tools.iterget_notes(client,invitation=conference_id+"/-/NeurIPS_Submission")
+for note in notes:
+    # need paper group to publish sub-groups
+    paper_group = client.post_group(openreview.Group(
+        id='{conference_id}/NeurIPS{number}'.format(conference_id=conference_id, number=note.number),
+        signatures=[conference_id], signatories=[conference_id],
+        readers=[conference_id], writers=[conference_id]))
+
+    notify_inv = openreview.Invitation(
+        id='{}/NeurIPS{}/-/Notification'.format(conference_id, note.number),
+        readers=['everyone'],
+        invitees=['~'],
+        writers=[conference_id],
+        signatures=[conference_id],
+        details= {'writable':True},
+        multiReply= False,
+        reply={
+            'forum': note.forum,
+            'replyto': note.forum,
+            'content': {
+                "tag": {
+                    "required": True,
+                    "description": "Frequency",
+                    "value-dropdown": [
+                        "Immediate",
+                        "Daily",
+                        "Weekly",
+                        "Never"
+                    ]
+                }
+            },
+            'signatures': {
+                'description': 'Your authorized identity to be associated with the above content.',
+                'values-regex': '~.*'
+            },
+            'readers': {
+                'description': 'The users who will be allowed to read the above content.',
+                'values': [conference_id]
+            },
+            'writers': {
+                'values-copied': [conference_id, '{signatures}']
+            }
+        }
+    )
+    client.post_invitation(notify_inv)
+
+    # add comment invite
+    comment_inv = openreview.Invitation(
+        id='{}/NeurIPS{}/-/Comment'.format(conference_id, note.number),
+        readers=['everyone'],
+        invitees=['~'],
+        writers=[conference_id],
+        signatures=[conference_id],
+        reply={
+            'forum': note.forum,
+            'replyto': None,
+            'content': {
+                'title': {
+                    'value-regex': '.*',
+                    'order': 0,
+                    'required': True
+                },
+                'comment': {
+                    'description': 'Your comment or reply (max 5000 characters).',
+                    'order': 1,
+                    'required': True,
+                    'value-regex': '[\\S\\s]{1,5000}'
+                }
+            },
+            'signatures': {
+                'description': 'Your authorized identity to be associated with the above content.',
+                'values-regex': '~.*'
+            },
+            'readers': {
+                'description': 'The users who will be allowed to read the above content.',
+                'values': ['everyone']
+            },
+            'writers': {
+                'values-copied': [conference_id, '{signatures}']
+            }
+        },
+        process='../process/commentProcess.py'
+    )
+    client.post_invitation(comment_inv)

--- a/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/python/comment_notification.py
+++ b/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/python/comment_notification.py
@@ -25,7 +25,7 @@ for note in notes:
         readers=[conference_id], writers=[conference_id]))
 
     notify_inv = openreview.Invitation(
-        id='{}/NeurIPS{}/-/Notification'.format(conference_id, note.number),
+        id='{}/NeurIPS{}/-/Comment_Notification'.format(conference_id, note.number),
         readers=['everyone'],
         invitees=['~'],
         writers=[conference_id],

--- a/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/python/comment_notification.py
+++ b/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/python/comment_notification.py
@@ -13,58 +13,57 @@ client = openreview.Client(baseurl=args.baseurl, username=args.username, passwor
 print("Connected to "+client.baseurl)
 conference_id = 'NeurIPS.cc/2019/Reproducibility_Challenge'
 
-# for each submission, create group (so sub invites can be published)
 # create invitation for notification frequency tags
+notify_inv = openreview.Invitation(
+    id='{}/-/Notification_Subscription'.format(conference_id),
+    readers=['everyone'],
+    invitees=['~'],
+    writers=[conference_id],
+    signatures=[conference_id],
+    details={'writable': True},
+    multiReply=False,
+    reply={
+        'invitation': conference_id+"/-/NeurIPS_Submission",
+        'content': {
+            "tag": {
+                "required": True,
+                "description": "Select Frequency",
+                "value-dropdown": [
+                    "Immediate",
+                    "Daily",
+                    "Weekly",
+                    "Never"
+                ]
+            }
+        },
+        'signatures': {
+            'description': 'Your authorized identity to be associated with the above content.',
+            'values-regex': '~.*'
+        },
+        'readers': {
+            'description': 'The users who will be allowed to read the above content.',
+            'values': [conference_id, conference_id+'/Program_Chairs', '{signatures}']
+        },
+        'writers': {
+            'values-copied': [conference_id, '{signatures}']
+        }
+    }
+)
+client.post_invitation(notify_inv)
+
+# for each submission, create group (so sub invites can be published)
 # create invite for comment
 notes = tools.iterget_notes(client,invitation=conference_id+"/-/NeurIPS_Submission")
 for note in notes:
     # need paper group to publish sub-groups
     paper_group = client.post_group(openreview.Group(
-        id='{conference_id}/NeurIPS{number}'.format(conference_id=conference_id, number=note.number),
+        id='{conference_id}/{number}'.format(conference_id=conference_id, number=note.number),
         signatures=[conference_id], signatories=[conference_id],
         readers=[conference_id], writers=[conference_id]))
 
-    notify_inv = openreview.Invitation(
-        id='{}/NeurIPS{}/-/Comment_Notification'.format(conference_id, note.number),
-        readers=['everyone'],
-        invitees=['~'],
-        writers=[conference_id],
-        signatures=[conference_id],
-        details= {'writable':True},
-        multiReply= False,
-        reply={
-            'forum': note.forum,
-            'replyto': note.forum,
-            'content': {
-                "tag": {
-                    "required": True,
-                    "description": "Frequency",
-                    "value-dropdown": [
-                        "Immediate",
-                        "Daily",
-                        "Weekly",
-                        "Never"
-                    ]
-                }
-            },
-            'signatures': {
-                'description': 'Your authorized identity to be associated with the above content.',
-                'values-regex': '~.*'
-            },
-            'readers': {
-                'description': 'The users who will be allowed to read the above content.',
-                'values': [conference_id]
-            },
-            'writers': {
-                'values-copied': [conference_id, '{signatures}']
-            }
-        }
-    )
-    client.post_invitation(notify_inv)
-
     # add comment invite
     comment_inv = openreview.Invitation(
-        id='{}/NeurIPS{}/-/Comment'.format(conference_id, note.number),
+        id=paper_group.id+'/-/Comment',
         readers=['everyone'],
         invitees=['~'],
         writers=[conference_id],

--- a/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/python/notify.py
+++ b/venues/reproducibility-challenge.github.io/Reproducibility_Challenge/NeurIPS/2019/python/notify.py
@@ -1,5 +1,6 @@
 
 import argparse
+import datetime
 import openreview
 from openreview import tools
 
@@ -8,7 +9,6 @@ parser.add_argument('--baseurl', help="base url")
 parser.add_argument('--username')
 parser.add_argument('--password')
 parser.add_argument('--freq', required=True, help="Daily or Weekly")
-parser.add_argument('--tcdate', required=True, help="Time in msec of last update")
 parser.add_argument('--notify_author', default=False)
 args = parser.parse_args()
 
@@ -37,7 +37,16 @@ def get_author_id(forumNote):
 
 
 # load recent comments
-comments = tools.iterget_notes(client, mintcdate = args.tcdate, invitation = conference_id+'/.*/-/Comment')
+min_date = datetime.datetime.utcnow().timestamp()*1000
+if args.freq == "Daily":
+    min_date -= 24*60*60*1000
+elif args.freq == "Weekly":
+    min_date -= 7*24*60*60*1000
+else:
+    print("Invalid freq: "+args.freq)
+    quit()
+
+comments = tools.iterget_notes(client, mintcdate = min_date, invitation = conference_id+'/.*/-/Comment')
 comment_by_forum = {}
 for comment in comments:
     if comment.forum not in comment_by_forum:


### PR DESCRIPTION
Do not merge yet - need to get scripts for Daily and Weekly notification options.

We use tags for each person to set their notification frequency for comments.  First authors are informed if they don't set a notification frequency.

The comment process function seems more complicated than strictly necessary, I may need to rework it.