### PR TITLE
Fix/anonymous preprint setup

### DIFF
--- a/venues/OpenReview.net/Anonymous_Preprint/python/admin-init.py
+++ b/venues/OpenReview.net/Anonymous_Preprint/python/admin-init.py
@@ -38,8 +38,8 @@ openreview_groups = [openreview.Group(**{
 groups.append(openreview.Group(config.AUTHORS, **config.group_params))
 
 conf_group = [n for n in openreview_groups if n.id == config.CONF][0]
-conf_group.signatures = [client.signature]
 conf_group.add_webfield(config.WEBPATH)
+print("Posting group: ", conf_group.id)
 client.post_group(conf_group)
 
 invitations = []
@@ -52,10 +52,9 @@ invitations.append(openreview.Invitation(
 # public comments are disabled for now
 
 for g in groups:
-    print "Posting group: ", g.id
-    print g
+    print("Posting group: ", g.id)
     client.post_group(g)
 
 for i in invitations:
-    print "Posting invitation: ", i.id
+    print("Posting invitation: ", i.id)
     client.post_invitation(i)

--- a/venues/OpenReview.net/Anonymous_Preprint/python/config.py
+++ b/venues/OpenReview.net/Anonymous_Preprint/python/config.py
@@ -92,7 +92,7 @@ submission_params = {
         },
         'signatures': {
             'description': 'Your authorized identity to be associated with the above content.',
-            'values-regex': '~.*|' + CONF
+            'values-regex': '~.*|^' + CONF + '$'
         },
         'writers': {
             'values': [CONF]

--- a/venues/OpenReview.net/Anonymous_Preprint/webfield/conferenceWebfield.js
+++ b/venues/OpenReview.net/Anonymous_Preprint/webfield/conferenceWebfield.js
@@ -7,13 +7,9 @@
 // ------------------------------------
 
 // Constants
-var CONFERENCE = "OpenReview.net/Anonymous_Preprint";
-var SUBMISSION = CONFERENCE + '/-/Submission';
-var BLIND_SUBMISSION = CONFERENCE + '/-/Blind_Submission';
-var SUBJECT_AREAS = [
-  // Add conference specific subject areas here
-];
-var BUFFER = 1000 * 60 * 30;  // 30 minutes
+var CONFERENCE_ID = "OpenReview.net/Anonymous_Preprint";
+var SUBMISSION_ID = CONFERENCE_ID + '/-/Submission';
+var BLIND_SUBMISSION_ID = CONFERENCE_ID + '/-/Blind_Submission';
 var PAGE_SIZE = 50;
 
 var paperDisplayOptions = {
@@ -24,13 +20,15 @@ var paperDisplayOptions = {
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
-  Webfield.ui.setup('#group-container', CONFERENCE);  // required
+  Webfield.ui.setup('#group-container', CONFERENCE_ID);  // required
 
   renderConferenceHeader();
 
-  load().then(render).then(function() {
-    Webfield.setupAutoLoading(BLIND_SUBMISSION, PAGE_SIZE, paperDisplayOptions);
-  });
+  renderSubmissionButton();
+
+  renderConferenceTabs();
+
+  load().then(renderContent).then(Webfield.ui.done);
 }
 
 // RenderConferenceHeader renders the static info at the top of the page. Since that content
@@ -60,52 +58,94 @@ function renderConferenceHeader() {
           <a href="mailto:info@openreview.net">info@openreview.net</a> with any questions or concerns. \</br>\</p>',
   });
 
-  Webfield.ui.spinner('#notes');
+  Webfield.ui.spinner('#notes', { inline: true });
+}
+
+function renderSubmissionButton() {
+  Webfield.api.getSubmissionInvitation(SUBMISSION_ID)
+    .then(function(invitation) {
+      Webfield.ui.submissionButton(invitation, user, {
+        onNoteCreated: function() {
+          // Callback function to be run when a paper has successfully been submitted (required)
+          promptMessage('Your submission is complete. Check your inbox for a confirmation email. ');
+          load().then(renderContent);
+        }
+      });
+    });
+}
+
+
+function renderConferenceTabs() {
+  var sections = [
+    {
+      heading: 'Papers Submitted',
+      id: 'all-submissions',
+    }
+  ];
+
+  Webfield.ui.tabPanel(sections, {
+    container: '#notes',
+    hidden: true
+  });
 }
 
 // Load makes all the API calls needed to get the data to render the page
 // It returns a jQuery deferred object: https://api.jquery.com/category/deferred-object/
 function load() {
-  var invitationP = Webfield.api.getSubmissionInvitation(SUBMISSION, {deadlineBuffer: BUFFER});
-  var notesP = Webfield.api.getSubmissions(BLIND_SUBMISSION, {pageSize: PAGE_SIZE});
-  return $.when(invitationP, notesP);
+  return Webfield.api.getSubmissions(BLIND_SUBMISSION_ID, {
+    pageSize: PAGE_SIZE,
+    details: 'replyCount,original',
+    includeCount: true
+  });
 }
 
 // Render is called when all the data is finished being loaded from the server
 // It should also be called when the page needs to be refreshed, for example after a user
 // submits a new paper.
-function render(invitation, notes) {
-  // Display submission button and form (if invitation is readable)
-  $('#invitation').empty();
-  if (invitation) {
-    Webfield.ui.submissionButton(invitation, user, {
-      onNoteCreated: function() {
-        // Callback funtion to be run when a paper has successfully been submitted (required)
-        load().then(render).then(function() {
-          Webfield.setupAutoLoading(BLIND_SUBMISSION, PAGE_SIZE, paperDisplayOptions);
-        });
-      }
-    });
-  }
+function renderContent(notesResponse) {
 
   // Display the list of all submitted papers
-  $('#notes').empty();
+  var notes = notesResponse.notes || [];
+  var noteCount = notesResponse.count || 0;
+
+  $('#all-submissions').empty();
+
+  var searchResultsListOptions = _.assign({}, paperDisplayOptions, {
+    container: '#all-submissions',
+    autoLoad: false
+  });
+
   Webfield.ui.submissionList(notes, {
-    heading: 'Submitted Papers',
-    displayOptions: paperDisplayOptions,
+    heading: null,
+    container: '#all-submissions',
     search: {
       enabled: true,
-      subjectAreas: SUBJECT_AREAS,
+      localSearch: false,
+      invitation: BLIND_SUBMISSION_ID,
       onResults: function(searchResults) {
-        Webfield.ui.searchResults(searchResults, paperDisplayOptions);
-        Webfield.disableAutoLoading();
+        Webfield.ui.searchResults(searchResults, searchResultsListOptions);
       },
       onReset: function() {
-        Webfield.ui.searchResults(notes, paperDisplayOptions);
-        Webfield.setupAutoLoading(BLIND_SUBMISSION, PAGE_SIZE, paperDisplayOptions);
+        Webfield.ui.searchResults(notes, searchResultsListOptions);
+        $('#all-submissions').append(view.paginationLinks(noteCount, PAGE_SIZE, 1));
       }
-    }
+    },
+    displayOptions: paperDisplayOptions,
+    autoLoad: false,
+    noteCount: noteCount,
+    pageSize: PAGE_SIZE,
+    onPageClick: function(offset) {
+      return Webfield.api.getSubmissions(BLIND_SUBMISSION_ID, {
+        details: 'replyCount,original',
+        pageSize: PAGE_SIZE,
+        offset: offset
+      });
+    },
+    fadeIn: false
   });
+
+  $('#notes .spinner-container').remove();
+  $('.tabs-container').show();
 }
 
 // Go!

--- a/venues/OpenReview.net/Anonymous_Preprint/webfield/conferenceWebfield.js
+++ b/venues/OpenReview.net/Anonymous_Preprint/webfield/conferenceWebfield.js
@@ -43,15 +43,12 @@ function renderConferenceHeader() {
     instructions: '<p><strong>Important Information about Anonymity:</strong><br>\
           When you post a submission to this anonymous preprint server, please provide the real names and email addresses of authors in the submission form below.\
           An anonymous record of your paper will appear in the list below, and will be visible to the public. \
-          The <em>original</em> record of your submission will be private, and will contain your real name(s); \
-          originals can be found in your OpenReview <a href="/tasks">Tasks page</a>.\
-          You can also access the original record of your paper by clicking the "Modifiable Original" \
-          link in the discussion forum page of your paper. The PDF in your submission should not contain the names of the authors. </p>\
-          <p><strong>Posting Revisions to Submissions:</strong><br>\
-          To post a revision to your paper, navigate to the original version, and click on the "Add Revision" button. \
-          Revisions on originals propagate all changes to anonymous copies, while maintaining anonymity.</p> \
-          <p><strong>Withdrawing Submissions:</strong><br>\
-          To withdraw your paper, navigate to the anonymous record of your submission and click on the "Withdraw" button. You will be asked to confirm your withdrawal. \
+          The real name(s) are privately revealed to you and all the co-authors. \
+          The PDF in your submission should not contain the names of the authors. </p>\
+          <p><strong>Revise your paper:</strong><br>\
+          To add a new version of your paper, go to the forum page of your paper and click on the "Revision" button. \
+          <p><strong>Withdraw your paper:</strong><br>\
+          To withdraw your paper, navigate to the forum page and click on the "Withdraw" button. You will be asked to confirm your withdrawal. \
           Withdrawn submissions will be removed from the system entirely. \
           <p><strong>Questions or Concerns:</strong><br> \
           Please contact the OpenReview support team at \


### PR DESCRIPTION
- Get bibtex using the current year
- Create revision invitation using blind note number
- Create withdraw invitation as a reply of the forum
- Fix withdraw process function and delete the blind and original note
- Create both invitation using the paper group id as prefix
- Fix signatures regex of the submission invitation
- Adapt the home page webfield to use the tab webfield template from the builder: pagination, tabs, search, original names, etc.
- Adapt the documentation to the new way of revise/withdraw a paper.

Michael please review 🙏 

