### PR TITLE
Replace old HTML webfields with current webfield templates

### DIFF
--- a/venues/ICLR.cc/2013/webfield/conferenceWebfield.js
+++ b/venues/ICLR.cc/2013/webfield/conferenceWebfield.js
@@ -1,0 +1,198 @@
+// Constants
+var CONFERENCE_ID = 'ICLR.cc/2013/conference';
+var BLIND_SUBMISSION_ID = 'ICLR.cc/2013/conference/-/submission';
+var WITHDRAWN_SUBMISSION_ID = '';
+var DESK_REJECTED_SUBMISSION_ID = '';
+var DECISION_INVITATION_REGEX = '';
+var DECISION_HEADING_MAP = {
+  'conferenceOral-iclr2013-conference': 'Conference Track - Oral',
+  'conferencePoster-iclr2013-conference': 'Conference Track - Poster',
+  'conferenceOral-iclr2013-workshop': 'Workshop Track - Oral',
+  'conferencePoster-iclr2013-workshop': 'Workshop Track - Poster',
+  'reject': 'Not Selected'
+};
+var PAGE_SIZE = 25;
+
+var HEADER = {
+  title: 'International Conference on Learning Representations',
+  subtitle: 'ICLR 2013',
+  deadline: '',
+  location: 'May 02 - 04, 2013, Scottsdale, Arizona, USA',
+  website: 'https://sites.google.com/site/representationlearning2013',
+  instructions: null,
+};
+
+var paperDisplayOptions = {
+  pdfLink: true,
+  replyCount: true,
+  showContents: true
+};
+
+var sections = [];
+
+// Main is the entry point to the webfield code and runs everything
+function main() {
+  Webfield.ui.setup('#group-container', CONFERENCE_ID);  // required
+
+  renderConferenceHeader();
+
+  renderConferenceTabs();
+
+  load().then(renderContent).then(Webfield.ui.done);
+}
+
+// Load makes all the API calls needed to get the data to render the page
+function load() {
+  var notesP = Webfield.getAll('/notes', {
+    invitation: BLIND_SUBMISSION_ID,
+    details: 'replyCount,invitation,original'
+  });
+
+  var withdrawnNotesP = WITHDRAWN_SUBMISSION_ID ? Webfield.getAll('/notes', {
+    invitation: WITHDRAWN_SUBMISSION_ID,
+    details: 'replyCount,invitation,original'
+  }) : $.Deferred().resolve([]);
+
+  var deskRejectedNotesP = DESK_REJECTED_SUBMISSION_ID ? Webfield.getAll('/notes', {
+    invitation: DESK_REJECTED_SUBMISSION_ID,
+    details: 'replyCount,invitation,original'
+  }) : $.Deferred().resolve([]);
+
+  var decisionNotesP = DECISION_INVITATION_REGEX ? Webfield.getAll('/notes', {
+    invitation: DECISION_INVITATION_REGEX,
+  }) : $.Deferred().resolve([]);
+
+  var userGroupsP;
+  if (!user || _.startsWith(user.id, 'guest_')) {
+    userGroupsP = $.Deferred().resolve([]);
+  } else {
+    userGroupsP = Webfield.getAll('/groups', {
+      regex: CONFERENCE_ID + '/.*',
+      member: user.id,
+      web: true
+    }).then(function(groups) {
+      if (!groups || !groups.length) {
+        return [];
+      }
+
+      return groups.map(function(g) { return g.id; });
+    });
+  }
+
+  return $.when(notesP, decisionNotesP, withdrawnNotesP, deskRejectedNotesP, userGroupsP);
+}
+
+function renderConferenceHeader() {
+  Webfield.ui.venueHeader(HEADER);
+  Webfield.ui.spinner('#notes', { inline: true });
+}
+
+function getElementId(decision) {
+  return decision.replace(' ', '-')
+    .replace('(', '')
+    .replace(')', '')
+    .toLowerCase();
+}
+
+function renderConferenceTabs() {
+  sections.push({
+    heading: 'Your Consoles',
+    id: 'your-consoles',
+  });
+  for (var decision in DECISION_HEADING_MAP) {
+    sections.push({
+      heading: DECISION_HEADING_MAP[decision],
+      id: getElementId(decision)
+    });
+  }
+
+  Webfield.ui.tabPanel(sections, {
+    container: '#notes',
+    hidden: true
+  });
+}
+
+function createConsoleLinks(allGroups) {
+  var uniqueGroups = _.sortedUniq(allGroups.sort());
+
+  return uniqueGroups.map(function(group) {
+    var groupName = group.split('/').pop();
+    if (groupName.slice(-1) === 's') {
+      groupName = groupName.slice(0, -1);
+    }
+
+    return [
+      '<li class="note invitation-link">',
+        '<a href="/group?id=' + group + '">' + groupName.replace(/_/g, ' ') + ' Console</a>',
+      '</li>'
+    ].join('');
+  });
+}
+
+function groupNotesByDecision(notes, decisionNotes, withdrawnNotes, deskRejectedNotes) {
+  // Categorize notes into buckets defined by DECISION_HEADING_MAP
+  var notesDict = _.keyBy(notes, 'id');
+
+  var papersByDecision = {};
+  for (var decision in DECISION_HEADING_MAP) {
+    papersByDecision[getElementId(decision)] = [];
+  }
+
+  decisionNotes.forEach(function(d) {
+    var decisionKey = getElementId(d.content.decision);
+    if (notesDict[d.forum] && papersByDecision[decisionKey]) {
+      papersByDecision[decisionKey].push(notesDict[d.forum]);
+    }
+  });
+
+  papersByDecision['reject'] = papersByDecision['reject'].concat(withdrawnNotes.concat(deskRejectedNotes));
+
+  return papersByDecision;
+}
+
+function renderContent(notes, decisionNotes, withdrawnNotes, deskRejectedNotes, userGroups) {
+  var papersByDecision = groupNotesByDecision(notes, notes, withdrawnNotes, deskRejectedNotes);
+
+  // Your Consoles Tab
+  if (userGroups && userGroups.length) {
+    var consoleLinks = createConsoleLinks(userGroups);
+    $('#your-consoles').html('<ul class="list-unstyled submissions-list">' +
+      consoleLinks.join('\n') + '</ul>');
+
+    $('.tabs-container a[href="#your-consoles"]').parent().show();
+  } else {
+    $('.tabs-container a[href="#your-consoles"]').parent().hide();
+  }
+
+  // Register event handlers
+  $('#group-container').on('shown.bs.tab', 'ul.nav-tabs li a', function(e) {
+    var containerSelector = $(e.target).attr('href');
+    var containerId = containerSelector.substring(1);
+    if (!papersByDecision.hasOwnProperty(containerId) || !$(containerSelector).length) {
+      return;
+    }
+
+    setTimeout(function() {
+      Webfield.ui.searchResults(
+        papersByDecision[containerId],
+        Object.assign({}, paperDisplayOptions, { showTags: false, container: containerSelector })
+      );
+    }, 150);
+  });
+
+  $('#group-container').on('hidden.bs.tab', 'ul.nav-tabs li a', function(e) {
+    var containerSelector = $(e.target).attr('href');
+    var containerId = containerSelector.substring(1);
+    if (!papersByDecision.hasOwnProperty(containerId) || !$(containerSelector).length) {
+      return;
+    }
+
+    Webfield.ui.spinner(containerSelector, { inline: true });
+  });
+
+  $('#notes > .spinner-container').remove();
+  $('.tabs-container').show();
+}
+
+// Go!
+main();

--- a/venues/ICLR.cc/2013/webfield/conferenceWebfieldOld.html
+++ b/venues/ICLR.cc/2013/webfield/conferenceWebfieldOld.html
@@ -1,0 +1,111 @@
+<html>
+<head>
+</head>
+<body>
+<div id='main'>
+    <div id='header'></div>
+    <div id='invitation'></div>
+    <div id='notes'></div>
+</div>
+<script type="text/javascript">
+    $(function () {
+
+      $attach('#header', 'mkHostHeader', [
+        "ICLR 2013",
+        "International Conference on Learning Representations",
+        "May 02 - 04, 2013, Scottsdale, Arizona, USA",
+        "https://sites.google.com/site/representationlearning2013/"
+      ], true);
+
+        var sm = mkStateManager();
+
+        var httpGetP = function (url, queryOrBody) {
+            var df = $.Deferred();
+            httpGet(url, queryOrBody,
+                function (result) {
+                    df.resolve(result);
+                },
+                function (result) {
+                    df.reject(result);
+                });
+            return df.promise();
+        };
+
+        var notesP = httpGetP('notes', {invitation: 'ICLR.cc/2013/conference/-/submission'}).then(function(result) {
+                return result.notes;
+            },
+            function (error) {
+                return error
+            });
+
+        $.when(notesP).done(function (notes) {
+
+            if (notes) {
+                var $panel = $('#notes');
+                $panel.empty();
+
+                var notesDict = {};
+
+                var workshopOralDecisions = [];
+                var workshopPosterDecisions = [];
+
+                var conferenceOralDecisions = [];
+                var conferencePosterDecisions = [];
+                var rejectDecisions = [];
+
+                _.forEach(notes, function (n) {
+                    notesDict[n.id] = n;
+
+                    if (n.content.decision == 'conferenceOral-iclr2013-conference') {
+                        conferenceOralDecisions.push(n);
+                    } else if (n.content.decision == 'conferencePoster-iclr2013-conference') {
+                        conferencePosterDecisions.push(n);
+                    } else if (n.content.decision == 'conferenceOral-iclr2013-workshop') {
+                        workshopOralDecisions.push(n);
+                    } else if (n.content.decision == 'conferencePoster-iclr2013-workshop') {
+                        workshopPosterDecisions.push(n);
+                    } else if (n.content.decision == 'reject') {
+                        rejectDecisions.push(n);
+                    }
+                });
+
+                $panel.append($('<div>').append($('<h1>').text('ICLR 2013 Conference Track')));
+                displayNotes(notesDict, conferenceOralDecisions, $panel, 'Accepted for Oral Presentation', '');
+                $panel.append($('<div>', {style: 'height: 50px;'}));
+                displayNotes(notesDict, conferencePosterDecisions, $panel, 'Accepted for Poster Presentation', '');
+                $panel.append($('<div>', {style: 'height: 50px;'}));
+
+                $panel.append($('<div>').append($('<h1>').text('ICLR 2013 Workshop Track')));
+                displayNotes(notesDict, workshopOralDecisions, $panel, 'Accepted for Oral Presentation', '');
+                $panel.append($('<div>', {style: 'height: 50px;'}));
+                displayNotes(notesDict, workshopPosterDecisions, $panel, 'Accepted for Poster Presentation', '');
+                $panel.append($('<div>', {style: 'height: 50px;'}));
+                displayNotes(notesDict, rejectDecisions, $panel, 'Not selected for presentation at this time', '');
+
+            }
+
+        });
+
+        function displayNotes(notes, decisions, $panel, text, summary) {
+            $panel.append($('<div>', {class: 'panel'}).append($('<h2>', {style: 'text-decoration: underline; '}).text(text)));
+
+            _.forEach(decisions, function (decision) {
+
+                var forum = notes[decision.forum];
+                if (forum) {
+                    $attach('#notes', 'mkNotePanel', [forum, {
+                        titleLink: 'HREF',
+                        withReplyCount: true,
+                        withSummary: summary
+                    }], true);
+                } else {
+                    console.log('Forum not found', decision.forum);
+                }
+
+            });
+
+        }
+    });
+</script>
+</body>
+</html>

--- a/venues/ICLR.cc/2014/webfield/conferenceWebfield.js
+++ b/venues/ICLR.cc/2014/webfield/conferenceWebfield.js
@@ -1,0 +1,196 @@
+// Constants
+var CONFERENCE_ID = 'ICLR.cc/2014/conference';
+var BLIND_SUBMISSION_ID = 'ICLR.cc/2014/conference/-/submission';
+var WITHDRAWN_SUBMISSION_ID = '';
+var DESK_REJECTED_SUBMISSION_ID = '';
+var DECISION_INVITATION_REGEX = '';
+var DECISION_HEADING_MAP = {
+  'submitted-papers': 'Submitted Papers',
+};
+var PAGE_SIZE = 25;
+
+var HEADER = {
+  title: 'International Conference on Learning Representations',
+  subtitle: 'ICLR 2014 Conference Track',
+  deadline: '',
+  location: 'Apr 14 - 16, 2014, Banff, Canada',
+  website: 'https://sites.google.com/site/representationlearning2014',
+  instructions: null,
+};
+
+var paperDisplayOptions = {
+  pdfLink: true,
+  replyCount: true,
+  showContents: true
+};
+
+var sections = [];
+
+// Main is the entry point to the webfield code and runs everything
+function main() {
+  Webfield.ui.setup('#group-container', CONFERENCE_ID);  // required
+
+  renderConferenceHeader();
+
+  renderConferenceTabs();
+
+  load().then(renderContent).then(Webfield.ui.done);
+}
+
+// Load makes all the API calls needed to get the data to render the page
+function load() {
+  var notesP = Webfield.getAll('/notes', {
+    invitation: BLIND_SUBMISSION_ID,
+    details: 'replyCount,invitation,original'
+  });
+
+  var withdrawnNotesP = WITHDRAWN_SUBMISSION_ID ? Webfield.getAll('/notes', {
+    invitation: WITHDRAWN_SUBMISSION_ID,
+    details: 'replyCount,invitation,original'
+  }) : $.Deferred().resolve([]);
+
+  var deskRejectedNotesP = DESK_REJECTED_SUBMISSION_ID ? Webfield.getAll('/notes', {
+    invitation: DESK_REJECTED_SUBMISSION_ID,
+    details: 'replyCount,invitation,original'
+  }) : $.Deferred().resolve([]);
+
+  var decisionNotesP = DECISION_INVITATION_REGEX ? Webfield.getAll('/notes', {
+    invitation: DECISION_INVITATION_REGEX,
+  }) : $.Deferred().resolve([]);
+
+  var userGroupsP;
+  if (!user || _.startsWith(user.id, 'guest_')) {
+    userGroupsP = $.Deferred().resolve([]);
+  } else {
+    userGroupsP = Webfield.getAll('/groups', {
+      regex: CONFERENCE_ID + '/.*',
+      member: user.id,
+      web: true
+    }).then(function(groups) {
+      if (!groups || !groups.length) {
+        return [];
+      }
+
+      return groups.map(function(g) { return g.id; });
+    });
+  }
+
+  return $.when(notesP, decisionNotesP, withdrawnNotesP, deskRejectedNotesP, userGroupsP);
+}
+
+function renderConferenceHeader() {
+  Webfield.ui.venueHeader(HEADER);
+  Webfield.ui.spinner('#notes', { inline: true });
+}
+
+function getElementId(decision) {
+  return decision.replace(' ', '-')
+    .replace('(', '')
+    .replace(')', '')
+    .toLowerCase();
+}
+
+function renderConferenceTabs() {
+  sections.push({
+    heading: 'Your Consoles',
+    id: 'your-consoles',
+  });
+  for (var decision in DECISION_HEADING_MAP) {
+    sections.push({
+      heading: DECISION_HEADING_MAP[decision],
+      id: getElementId(decision)
+    });
+  }
+
+  Webfield.ui.tabPanel(sections, {
+    container: '#notes',
+    hidden: true
+  });
+}
+
+function createConsoleLinks(allGroups) {
+  var uniqueGroups = _.sortedUniq(allGroups.sort());
+
+  return uniqueGroups.map(function(group) {
+    var groupName = group.split('/').pop();
+    if (groupName.slice(-1) === 's') {
+      groupName = groupName.slice(0, -1);
+    }
+
+    return [
+      '<li class="note invitation-link">',
+        '<a href="/group?id=' + group + '">' + groupName.replace(/_/g, ' ') + ' Console</a>',
+      '</li>'
+    ].join('');
+  });
+}
+
+function groupNotesByDecision(notes, decisionNotes, withdrawnNotes, deskRejectedNotes) {
+  // Categorize notes into buckets defined by DECISION_HEADING_MAP
+  var notesDict = _.keyBy(notes, 'id');
+
+  var papersByDecision = {};
+  for (var decision in DECISION_HEADING_MAP) {
+    papersByDecision[getElementId(decision)] = [];
+  }
+
+  decisionNotes.forEach(function(d) {
+    var decisionKey = getElementId(d.content.decision);
+    if (notesDict[d.forum] && papersByDecision[decisionKey]) {
+      papersByDecision[decisionKey].push(notesDict[d.forum]);
+    }
+  });
+
+  papersByDecision['reject'] = papersByDecision['reject'].concat(withdrawnNotes.concat(deskRejectedNotes));
+
+  return papersByDecision;
+}
+
+function renderContent(notes, decisionNotes, withdrawnNotes, deskRejectedNotes, userGroups) {
+  var papersByDecision = {
+    'submitted-papers': notes
+  };
+
+  // Your Consoles Tab
+  if (userGroups && userGroups.length) {
+    var consoleLinks = createConsoleLinks(userGroups);
+    $('#your-consoles').html('<ul class="list-unstyled submissions-list">' +
+      consoleLinks.join('\n') + '</ul>');
+
+    $('.tabs-container a[href="#your-consoles"]').parent().show();
+  } else {
+    $('.tabs-container a[href="#your-consoles"]').parent().hide();
+  }
+
+  // Register event handlers
+  $('#group-container').on('shown.bs.tab', 'ul.nav-tabs li a', function(e) {
+    var containerSelector = $(e.target).attr('href');
+    var containerId = containerSelector.substring(1);
+    if (!papersByDecision.hasOwnProperty(containerId) || !$(containerSelector).length) {
+      return;
+    }
+
+    setTimeout(function() {
+      Webfield.ui.searchResults(
+        papersByDecision[containerId],
+        Object.assign({}, paperDisplayOptions, { showTags: false, container: containerSelector })
+      );
+    }, 150);
+  });
+
+  $('#group-container').on('hidden.bs.tab', 'ul.nav-tabs li a', function(e) {
+    var containerSelector = $(e.target).attr('href');
+    var containerId = containerSelector.substring(1);
+    if (!papersByDecision.hasOwnProperty(containerId) || !$(containerSelector).length) {
+      return;
+    }
+
+    Webfield.ui.spinner(containerSelector, { inline: true });
+  });
+
+  $('#notes > .spinner-container').remove();
+  $('.tabs-container').show();
+}
+
+// Go!
+main();

--- a/venues/ICLR.cc/2014/webfield/conferenceWebfieldOld.html
+++ b/venues/ICLR.cc/2014/webfield/conferenceWebfieldOld.html
@@ -1,0 +1,106 @@
+<html>
+<head>
+</head>
+<body>
+<div id='main'>
+    <div id='header'></div>
+    <div id='invitation'></div>
+    <div id='notes'></div>
+</div>
+<script type="text/javascript">
+    $(function () {
+
+        $attach('#header', 'mkHostHeader', [
+            "ICLR 2014",
+            "International Conference on Learning Representations",
+            "Apr 14 - 16, 2014, Banff, Canada",
+            "https://sites.google.com/site/representationlearning2014/"
+        ], true);
+
+        var sm = mkStateManager();
+
+        var httpGetP = function (url, queryOrBody) {
+            var df = $.Deferred();
+            httpGet(url, queryOrBody,
+                function (result) {
+                    df.resolve(result);
+                },
+                function (result) {
+                    df.reject(result);
+                });
+            return df.promise();
+        };
+
+        var workshopNotesP = httpGetP('notes', {invitation: 'ICLR.cc/2014/workshop/-/submission'}).then(function (result) {
+                return result.notes;
+            },
+            function (error) {
+                return error
+            });
+
+        var conferenceNotesP = httpGetP('notes', {invitation: 'ICLR.cc/2014/conference/-/submission'}).then(function (result) {
+                return result.notes;
+            },
+            function (error) {
+                return error
+            });
+
+        $.when(workshopNotesP, conferenceNotesP).done(function (workshopNotes, conferenceNotes) {
+
+            var $panel = $('#notes');
+            $panel.empty();
+
+            if (workshopNotes) {
+
+                var notesDict = {};
+                var workshopDecisions = [];
+
+                _.forEach(workshopNotes, function (n) {
+                    notesDict[n.id] = n;
+                    workshopDecisions.push(n);
+                });
+
+                $panel.append($('<div>').append($('<h1>').text('ICLR 2014 Workshop Track')));
+                displayNotes(notesDict, workshopDecisions, $panel, 'Submitted Papers', '');
+
+            }
+            if (conferenceNotes) {
+
+                var notesDict = {};
+                var conferenceDecisions = [];
+
+                _.forEach(conferenceNotes, function (n) {
+                    notesDict[n.id] = n;
+                    conferenceDecisions.push(n);
+                });
+
+                $panel.append($('<div>').append($('<h1>').text('ICLR 2014 Conference Track')));
+                displayNotes(notesDict, conferenceDecisions, $panel, 'Submitted Papers', '');
+
+            }
+
+        });
+
+        function displayNotes(notes, decisions, $panel, text, summary) {
+            $panel.append($('<div>', {class: 'panel'}).append($('<h2>', {style: 'text-decoration: underline; '}).text(text)));
+
+            _.forEach(decisions, function (decision) {
+
+                var forum = notes[decision.forum];
+                if (forum) {
+                    $attach('#notes', 'mkNotePanel', [forum, {
+                        titleLink: 'HREF',
+                        withReplyCount: true,
+                        withSummary: summary
+                    }], true);
+                } else {
+                    console.log('Forum not found', decision.forum);
+                }
+
+            });
+
+        }
+    });
+</script>
+</body>
+</html>

--- a/venues/ICLR.cc/2014/webfield/workshopWebfield.js
+++ b/venues/ICLR.cc/2014/webfield/workshopWebfield.js
@@ -1,0 +1,196 @@
+// Constants
+var CONFERENCE_ID = 'ICLR.cc/2014/workshop';
+var BLIND_SUBMISSION_ID = 'ICLR.cc/2014/workshop/-/submission';
+var WITHDRAWN_SUBMISSION_ID = '';
+var DESK_REJECTED_SUBMISSION_ID = '';
+var DECISION_INVITATION_REGEX = '';
+var DECISION_HEADING_MAP = {
+  'submitted-papers': 'Submitted Papers',
+};
+var PAGE_SIZE = 25;
+
+var HEADER = {
+  title: 'International Conference on Learning Representations',
+  subtitle: 'ICLR 2014 Workshop Track',
+  deadline: '',
+  location: 'Apr 14 - 16, 2014, Banff, Canada',
+  website: 'https://sites.google.com/site/representationlearning2014',
+  instructions: null,
+};
+
+var paperDisplayOptions = {
+  pdfLink: true,
+  replyCount: true,
+  showContents: true
+};
+
+var sections = [];
+
+// Main is the entry point to the webfield code and runs everything
+function main() {
+  Webfield.ui.setup('#group-container', CONFERENCE_ID);  // required
+
+  renderConferenceHeader();
+
+  renderConferenceTabs();
+
+  load().then(renderContent).then(Webfield.ui.done);
+}
+
+// Load makes all the API calls needed to get the data to render the page
+function load() {
+  var notesP = Webfield.getAll('/notes', {
+    invitation: BLIND_SUBMISSION_ID,
+    details: 'replyCount,invitation,original'
+  });
+
+  var withdrawnNotesP = WITHDRAWN_SUBMISSION_ID ? Webfield.getAll('/notes', {
+    invitation: WITHDRAWN_SUBMISSION_ID,
+    details: 'replyCount,invitation,original'
+  }) : $.Deferred().resolve([]);
+
+  var deskRejectedNotesP = DESK_REJECTED_SUBMISSION_ID ? Webfield.getAll('/notes', {
+    invitation: DESK_REJECTED_SUBMISSION_ID,
+    details: 'replyCount,invitation,original'
+  }) : $.Deferred().resolve([]);
+
+  var decisionNotesP = DECISION_INVITATION_REGEX ? Webfield.getAll('/notes', {
+    invitation: DECISION_INVITATION_REGEX,
+  }) : $.Deferred().resolve([]);
+
+  var userGroupsP;
+  if (!user || _.startsWith(user.id, 'guest_')) {
+    userGroupsP = $.Deferred().resolve([]);
+  } else {
+    userGroupsP = Webfield.getAll('/groups', {
+      regex: CONFERENCE_ID + '/.*',
+      member: user.id,
+      web: true
+    }).then(function(groups) {
+      if (!groups || !groups.length) {
+        return [];
+      }
+
+      return groups.map(function(g) { return g.id; });
+    });
+  }
+
+  return $.when(notesP, decisionNotesP, withdrawnNotesP, deskRejectedNotesP, userGroupsP);
+}
+
+function renderConferenceHeader() {
+  Webfield.ui.venueHeader(HEADER);
+  Webfield.ui.spinner('#notes', { inline: true });
+}
+
+function getElementId(decision) {
+  return decision.replace(' ', '-')
+    .replace('(', '')
+    .replace(')', '')
+    .toLowerCase();
+}
+
+function renderConferenceTabs() {
+  sections.push({
+    heading: 'Your Consoles',
+    id: 'your-consoles',
+  });
+  for (var decision in DECISION_HEADING_MAP) {
+    sections.push({
+      heading: DECISION_HEADING_MAP[decision],
+      id: getElementId(decision)
+    });
+  }
+
+  Webfield.ui.tabPanel(sections, {
+    container: '#notes',
+    hidden: true
+  });
+}
+
+function createConsoleLinks(allGroups) {
+  var uniqueGroups = _.sortedUniq(allGroups.sort());
+
+  return uniqueGroups.map(function(group) {
+    var groupName = group.split('/').pop();
+    if (groupName.slice(-1) === 's') {
+      groupName = groupName.slice(0, -1);
+    }
+
+    return [
+      '<li class="note invitation-link">',
+        '<a href="/group?id=' + group + '">' + groupName.replace(/_/g, ' ') + ' Console</a>',
+      '</li>'
+    ].join('');
+  });
+}
+
+function groupNotesByDecision(notes, decisionNotes, withdrawnNotes, deskRejectedNotes) {
+  // Categorize notes into buckets defined by DECISION_HEADING_MAP
+  var notesDict = _.keyBy(notes, 'id');
+
+  var papersByDecision = {};
+  for (var decision in DECISION_HEADING_MAP) {
+    papersByDecision[getElementId(decision)] = [];
+  }
+
+  decisionNotes.forEach(function(d) {
+    var decisionKey = getElementId(d.content.decision);
+    if (notesDict[d.forum] && papersByDecision[decisionKey]) {
+      papersByDecision[decisionKey].push(notesDict[d.forum]);
+    }
+  });
+
+  papersByDecision['reject'] = papersByDecision['reject'].concat(withdrawnNotes.concat(deskRejectedNotes));
+
+  return papersByDecision;
+}
+
+function renderContent(notes, decisionNotes, withdrawnNotes, deskRejectedNotes, userGroups) {
+  var papersByDecision = {
+    'submitted-papers': notes
+  };
+
+  // Your Consoles Tab
+  if (userGroups && userGroups.length) {
+    var consoleLinks = createConsoleLinks(userGroups);
+    $('#your-consoles').html('<ul class="list-unstyled submissions-list">' +
+      consoleLinks.join('\n') + '</ul>');
+
+    $('.tabs-container a[href="#your-consoles"]').parent().show();
+  } else {
+    $('.tabs-container a[href="#your-consoles"]').parent().hide();
+  }
+
+  // Register event handlers
+  $('#group-container').on('shown.bs.tab', 'ul.nav-tabs li a', function(e) {
+    var containerSelector = $(e.target).attr('href');
+    var containerId = containerSelector.substring(1);
+    if (!papersByDecision.hasOwnProperty(containerId) || !$(containerSelector).length) {
+      return;
+    }
+
+    setTimeout(function() {
+      Webfield.ui.searchResults(
+        papersByDecision[containerId],
+        Object.assign({}, paperDisplayOptions, { showTags: false, container: containerSelector })
+      );
+    }, 150);
+  });
+
+  $('#group-container').on('hidden.bs.tab', 'ul.nav-tabs li a', function(e) {
+    var containerSelector = $(e.target).attr('href');
+    var containerId = containerSelector.substring(1);
+    if (!papersByDecision.hasOwnProperty(containerId) || !$(containerSelector).length) {
+      return;
+    }
+
+    Webfield.ui.spinner(containerSelector, { inline: true });
+  });
+
+  $('#notes > .spinner-container').remove();
+  $('.tabs-container').show();
+}
+
+// Go!
+main();

--- a/venues/ICLR.cc/2014/webfield/workshopWebfieldOld.html
+++ b/venues/ICLR.cc/2014/webfield/workshopWebfieldOld.html
@@ -1,0 +1,106 @@
+<html>
+<head>
+</head>
+<body>
+<div id='main'>
+    <div id='header'></div>
+    <div id='invitation'></div>
+    <div id='notes'></div>
+</div>
+<script type="text/javascript">
+    $(function () {
+
+        $attach('#header', 'mkHostHeader', [
+            "ICLR 2014",
+            "International Conference on Learning Representations",
+            "Apr 14 - 16, 2014, Banff, Canada",
+            "https://sites.google.com/site/representationlearning2014/"
+        ], true);
+
+        var sm = mkStateManager();
+
+        var httpGetP = function (url, queryOrBody) {
+            var df = $.Deferred();
+            httpGet(url, queryOrBody,
+                function (result) {
+                    df.resolve(result);
+                },
+                function (result) {
+                    df.reject(result);
+                });
+            return df.promise();
+        };
+
+        var workshopNotesP = httpGetP('notes', {invitation: 'ICLR.cc/2014/workshop/-/submission'}).then(function (result) {
+                return result.notes;
+            },
+            function (error) {
+                return error
+            });
+
+        var conferenceNotesP = httpGetP('notes', {invitation: 'ICLR.cc/2014/conference/-/submission'}).then(function (result) {
+                return result.notes;
+            },
+            function (error) {
+                return error
+            });
+
+        $.when(workshopNotesP, conferenceNotesP).done(function (workshopNotes, conferenceNotes) {
+
+            var $panel = $('#notes');
+            $panel.empty();
+
+            if (workshopNotes) {
+
+                var notesDict = {};
+                var workshopDecisions = [];
+
+                _.forEach(workshopNotes, function (n) {
+                    notesDict[n.id] = n;
+                    workshopDecisions.push(n);
+                });
+
+                $panel.append($('<div>').append($('<h1>').text('ICLR 2014 Workshop Track')));
+                displayNotes(notesDict, workshopDecisions, $panel, 'Submitted Papers', '');
+
+            }
+            if (conferenceNotes) {
+
+                var notesDict = {};
+                var conferenceDecisions = [];
+
+                _.forEach(conferenceNotes, function (n) {
+                    notesDict[n.id] = n;
+                    conferenceDecisions.push(n);
+                });
+
+                $panel.append($('<div>').append($('<h1>').text('ICLR 2014 Conference Track')));
+                displayNotes(notesDict, conferenceDecisions, $panel, 'Submitted Papers', '');
+
+            }
+
+        });
+
+        function displayNotes(notes, decisions, $panel, text, summary) {
+            $panel.append($('<div>', {class: 'panel'}).append($('<h2>', {style: 'text-decoration: underline; '}).text(text)));
+
+            _.forEach(decisions, function (decision) {
+
+                var forum = notes[decision.forum];
+                if (forum) {
+                    $attach('#notes', 'mkNotePanel', [forum, {
+                        titleLink: 'HREF',
+                        withReplyCount: true,
+                        withSummary: summary
+                    }], true);
+                } else {
+                    console.log('Forum not found', decision.forum);
+                }
+
+            });
+
+        }
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes ICLR.cc/2013/conference, ICLR.cc/2014/conference, and ICLR.cc/2014/workshop

Uses the tabsConferenceDecisionsWebfield template