### PR TITLE
Virtual Setup: add start end timestamp to presentation presentations

### DIFF
--- a/venues/virtual/python/setup.py
+++ b/venues/virtual/python/setup.py
@@ -191,7 +191,7 @@ meta_data_codeofconduct={
         {
             "name": "Markdown",
             "option": {
-                "center": false
+                "center": False
             },
             "content": "# ICLR Code of Conduct\n\n\nThe open exchange of ideas, the freedom of thought and expression, and respectful scientific debate are central to the goals of this conference on machine learning; this requires a community and an environment that recognizes and respects the inherent worth of every person.\n\n# Who\nAll participants---attendees, organizers, reviewers, speakers, sponsors, and volunteers at our conference, workshops, and conference-sponsored social events---are required to agree with this Code of Conduct both during the event and on official communication channels, including social media. Organizers will enforce this code, and we expect cooperation from all participants to help ensure a safe and productive environment for everybody.\n\n# Scope\nThe conference commits itself to provide an experience for all participants that is free from harassment, bullying, discrimination, and retaliation. This includes offensive comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), politics, technology choices, or any other personal characteristics. Bullying, intimidation, personal attacks, harassment, sustained disruption of talks or other events, and behavior that interferes with another participant's full participation will not be tolerated. This includes sexual harassment, stalking, following, harassing photography or recording, inappropriate physical contact, unwelcome sexual attention, public vulgar exchanges, and diminutive characterizations, which are all unwelcome in this community.\n\nThe expected behaviour in line with the scope above extends to any format of the conference, including any virtual forms, and to the use of any online tools related to the conference. These include comments on OpenReview within or outside of reviewing periods, conference-wide chat tools, Q&A tools, live stream interactions, and any other forms of virtual interaction. Trolling, use of inappropriate imagery or videos, offensive language either written or in-person over video or audio, unwarranted direct messages (DMs), and extensions of such behaviour to tools outside those used by the conference but related to the conference, its program and attendees, are not allowed. In addition, doxxing or revealing any personal information to target any participant will not be tolerated.\n\nSponsors are equally subject to this Code of Conduct. In particular, sponsors should not use images, activities, or other materials that are of a sexual, racial, or otherwise offensive nature. Sponsor representatives and staff (including volunteers) should not use sexualized clothing/uniforms/costumes or otherwise create a sexualized environment. This code applies both to official sponsors as well as any organization that uses the conference name as branding as part of its activities at or around the conference.\n\n# Outcomes\nParticipants asked by any member of the community to stop any such behavior are expected to comply immediately. If a participant engages in such behavior, the conference organizers may take any action they deem appropriate, including: a formal or informal warning to the offender, expulsion from the conference (either physical expulsion, or termination of access codes) with no refund, barring from participation in future conferences or their organization, reporting the incident to the offender’s local institution or funding agencies, or reporting the incident to local law enforcement. A response of \"just joking\" will not be accepted; behavior can be harassing without an intent to offend. If action is taken, an appeals process will be made available.\n\n# Reporting\nIf you have concerns related to your inclusion at that conference, or observe someone else's difficulties, or have any other concerns related to inclusion, please email the [ICLR 2021 Program Chairs](mailto:iclr2021programchairs@googlegroups.com).  For online events and tools, there are options to directly report specific chat/text comments, in addition to the above reporting. Complaints and violations will be handled with discretion. Reports made during the conference will be responded to within 24 hours; those at other times in less than two weeks. We are prepared and eager to help participants contact relevant help services, to escort them to a safe location, or to otherwise assist those experiencing harassment to feel safe for the duration of the conference. We gratefully accept feedback from the community on policy and actions; please contact us.\n\nUpdated March 29, 2020"
         }
@@ -563,7 +563,9 @@ client.post_invitation(openreview.Invitation(
             'bio': { 'value-regex': '.*' },
             'site': { 'value-regex': '.*' },
             'authors': { 'values-regex': '.*' },
-            'authorids': { 'values-regex': '.*' }
+            'authorids': { 'values-regex': '.*' },
+            'start': {'value-regex': '.*'},
+            'end': {'value-regex': '.*'},
         }
     }
 ))
@@ -624,6 +626,7 @@ with open('/Users/mbok/iesl/data/iclr2021/papers_iclr_2020.json') as f:
 index=0
 papers = client.get_notes(invitation=presentation_invitation_id)
 for day in days:
+    sessionNote = client.get_note(sessions[f'{day} Presentation Session'].id)
     for n in range(0, 6):
         presentation_note = papers[index]
         presentation_note.content = {
@@ -633,6 +636,8 @@ for day in days:
             'sessions': [sessions[f'{day} Presentation Session'].id],
             'presentation_type': 'presentation',
             'topic': presentation_note.content['topic'],
+            'start': sessionNote.content['start'], # set to be the same as session, ideally should distribute among presentations in the session
+            'end': sessionNote.content['end'],
         }
         client.post_note(presentation_note)
         index+=10

--- a/venues/virtual/python/setup.py
+++ b/venues/virtual/python/setup.py
@@ -865,3 +865,22 @@ presentation_1 = client.post_note(openreview.Note(
         'site': 'https://iclr.6connex.com/event/VirtualEvent'
     }
 ))
+
+#create invitation for welcome wall
+presentation_invitation_id = f"{virtual_group_id}/-/welcomewall"
+client.post_invitation(openreview.Invitation(
+    id=presentation_invitation_id,
+    readers=['everyone'],
+    writers=[conference_id],
+    invitees=[conference_id,'~'],
+    signatures=[conference_id],
+    reply={
+        'readers': {'values': ['everyone']},
+        'writers': {'values': [conference_id]},
+        'signatures': {'value-regex': '~.*'},
+        'content': {
+            'author': {'value-regex': '.*'},
+            'message': {'value-regex': '.*'},
+        }
+    }
+))

--- a/venues/virtual/python/setup.py
+++ b/venues/virtual/python/setup.py
@@ -880,7 +880,7 @@ client.post_invitation(openreview.Invitation(
         'signatures': {'value-regex': '~.*'},
         'content': {
             'author': {'value-regex': '.*'},
-            'message': {'value-regex': '.*'},
+            'message': {'value-regex': '[\s\S]*'},
         }
     }
 ))

--- a/venues/virtual/python/setup.py
+++ b/venues/virtual/python/setup.py
@@ -626,7 +626,6 @@ with open('/Users/mbok/iesl/data/iclr2021/papers_iclr_2020.json') as f:
 index=0
 papers = client.get_notes(invitation=presentation_invitation_id)
 for day in days:
-    sessionNote = client.get_note(sessions[f'{day} Presentation Session'].id)
     for n in range(0, 6):
         presentation_note = papers[index]
         presentation_note.content = {
@@ -636,8 +635,8 @@ for day in days:
             'sessions': [sessions[f'{day} Presentation Session'].id],
             'presentation_type': 'presentation',
             'topic': presentation_note.content['topic'],
-            'start': sessionNote.content['start'], # set to be the same as session, ideally should distribute among presentations in the session
-            'end': sessionNote.content['end'],
+            'start': sessions[f'{day} Presentation Session'].content['start'] + n*20*60*1000,
+            'end': sessions[f'{day} Presentation Session'].content['start'] + n*20*60*1000 + 20*60*1000
         }
         client.post_note(presentation_note)
         index+=10


### PR DESCRIPTION
add two new properties : start,end to presentation invitation

add start and end to presentations with presentation type "presentation"
the start and end time stamp is set to be equal to session note associated temporarily.