### PR TITLE
Workshops withdraw function

### DIFF
--- a/venues/aclweb.org/Workshops/camera_ready_process.py
+++ b/venues/aclweb.org/Workshops/camera_ready_process.py
@@ -1,0 +1,33 @@
+def process_update(client, note, invitation, existing_note):
+    SHORT_PHRASE = ''
+    AUTHOR_ID = ''
+   
+
+    action = 'posted'
+    if existing_note:
+        action = 'deleted' if note.ddate else 'updated'
+
+    forum = client.get_note(note.forum)
+
+    title = note.content.get('title', forum.content.get('title', ''))
+    authorids = note.content.get('authorids', forum.content.get('authorids', []))
+    abstract = note.content.get('abstract', forum.content.get('abstract', ''))
+
+    subject = '{} has received a new revision of your submission titled {}'.format(SHORT_PHRASE, title)
+    message = '''Your new revision of the submission to {} has been {}.
+
+Title: {}
+
+Abstract: {}
+
+To view your submission, click here: https://openreview.net/forum?id={}'''.format(SHORT_PHRASE, action, title, abstract, forum.id)
+
+    client.post_message(subject=subject, recipients=authorids, message=message)
+
+    if note.content.get('authorids'):
+        author_group = openreview.tools.get_group(client, AUTHOR_ID)
+        if author_group:
+            author_group.members = authorids
+            client.post_group(author_group)
+
+    

--- a/venues/aclweb.org/Workshops/create_invitations_workshops_both.py
+++ b/venues/aclweb.org/Workshops/create_invitations_workshops_both.py
@@ -131,7 +131,29 @@ submission_invitation_content = {"title": {
                 "value-regex": "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+",
                 "required": True,
                 "order": 10
-                } 
+                },
+                "previous_PDF": {
+"description": "If this is a resubmission, upload a single PDF of your previous submission to ACL Rolling Review.",
+"order": 19,
+"value-file": {
+"fileTypes": [
+"pdf"
+],
+"size": 80
+},
+"required": False
+},
+"response_PDF": {
+"description": "If this is a resubmission, upload a single PDF of your responses to the previous reviews to ACL Rolling Review.",
+"order": 20,
+"value-file": {
+"fileTypes": [
+"pdf"
+],
+"size": 80
+},
+"required": False
+} 
     }
 for key in commitment_invitation.reply['content'].keys(): 
     if key != 'existing_preprints':
@@ -557,7 +579,21 @@ metareview = openreview.Invitation(
       "description": "Independent of your judgement of the quality of the work, please review the ACL code of ethics (https://www.aclweb.org/portal/content/acl-code-ethics) and list any ethical concerns related to this paper. Maximum length 2000 characters.",
       "required": False,
       "markdown": True
-    }
+    },
+    "great_reviews": {
+"order": 7,
+"value-regex": "[\\S\\s]{0,2000}",
+"description": "Please list the ids of all reviewers who went beyond expectations in terms of providing informative and constructive reviews and discussion. For example: jAxb, zZac",
+"required": False,
+"markdown": True
+},
+"poor_reviews": {
+"order": 8,
+"value-regex": "[\\S\\s]{0,2000}",
+"description": "Please list the ids of all reviewers whose reviews did not meet expectations. For example: jAxb, zZac",
+"required": False,
+"markdown": True
+}
             }
         } 
     )

--- a/venues/aclweb.org/Workshops/create_invitations_workshops_one.py
+++ b/venues/aclweb.org/Workshops/create_invitations_workshops_one.py
@@ -524,6 +524,29 @@ metareview = openreview.Invitation(
       "description": "Independent of your judgement of the quality of the work, please review the ACL code of ethics (https://www.aclweb.org/portal/content/acl-code-ethics) and list any ethical concerns related to this paper. Maximum length 2000 characters.",
       "required": False,
       "markdown": True
+    },
+    "needs_ethics_review": {
+      "order": 7,
+      "value-radio": [
+        "Yes"
+      ],
+      "description": "Should this paper be sent for an in-depth ethics review? We have a small ethics committee that can specially review very challenging papers when it comes to ethical issues. If this seems to be such a paper, then please explain why here, and we will try to ensure that it receives a separate review.",
+      "required": False,
+      "markdown": True
+    },
+    "great_reviews": {
+      "order": 8,
+      "value-regex": "[\\S\\s]{0,2000}",
+      "description": "Please list the ids of all reviewers who went beyond expectations in terms of providing informative and constructive reviews and discussion. For example: jAxb, zZac",
+      "required": False,
+      "markdown": True
+    },
+    "poor_reviews": {
+      "order": 9,
+      "value-regex": "[\\S\\s]{0,2000}",
+      "description": "Please list the ids of all reviewers whose reviews did not meet expectations. For example: jAxb, zZac",
+      "required": False,
+      "markdown": True
     }
             }
         } 

--- a/venues/aclweb.org/Workshops/create_invitations_workshops_one.py
+++ b/venues/aclweb.org/Workshops/create_invitations_workshops_one.py
@@ -131,7 +131,16 @@ submission_invitation_content = {"title": {
                 "value-regex": "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+",
                 "required": True,
                 "order": 10
-                } 
+                } ,
+                "paper_type": {
+      "description": "Short or long. See the CFP for the requirements for short and long papers.",
+      "value-radio": [
+        "long",
+        "short"
+      ],
+      "order": 17,
+      "required": False
+    },
     }
 for key in commitment_invitation.reply['content'].keys(): 
     if key != 'existing_preprints':

--- a/venues/aclweb.org/Workshops/migrate_submissions_workshops_both.py
+++ b/venues/aclweb.org/Workshops/migrate_submissions_workshops_both.py
@@ -45,8 +45,10 @@ def post_acl_submission(arr_submission_forum, acl_commitment_note, submission_ou
             conf_submission_invitation = client.get_invitation(f"{confid}/-/Migrated_Submission")
             for key in acl_commitment_note.content.keys():
                 content[key] = acl_commitment_note.content[key]
+            
             for key in original_arr_sub.content.keys():
                 if key in conf_submission_invitation.reply['content']:
+                    
                     content[key] = original_arr_sub.content[key]
             content['paper_link'] =f'https://openreview.net/forum?id={arr_submission_forum}'
             content['commitment_note'] = f"https://openreview.net/forum?id={acl_commitment_note.forum}"
@@ -276,8 +278,8 @@ def post_reviews(acl_blind_submission_forum, acl_blind_submission, arr_submissio
             )
             acl_review.content['title'] = f'Official Review of Paper{acl_blind_submission.number} by {arr_review.invitation.split("/")[4]} Reviewer'
             #acl_review.content['link_to_original_review'] = f'https://openreview.net/forum?id={arr_review.forum}&noteId={arr_review.id}'
-            profile = client.get_profile(arr_review.tauthor)
-            acl_review.content['reviewer_id'] = f"{profile.id}"
+            #profile = client.get_profile(arr_review.tauthor)
+            #acl_review.content['reviewer_id'] = f"{profile.id}"
             acl_review_posted = client.post_note(acl_review)
             assert acl_review_posted, print('failed to post review ', acl_review.id)
             acl_reviews_dictionary[acl_review_posted.signatures[0]] = acl_review_posted.replyto
@@ -315,8 +317,8 @@ def post_metareviews(acl_blind_submission_forum, acl_blind_submission, arr_submi
             )
             #acl_metareview.content['link_to_original_metareview'] = f'https://openreview.net/forum?id={arr_metareview.forum}&noteId={arr_metareview.id}'
             acl_metareview.content['title'] = f'Meta Review of Paper{acl_blind_submission.number} by {arr_metareview.invitation.split("/")[4]} Area Chair'
-            profile = client.get_profile(arr_metareview.tauthor)
-            acl_metareview.content['action_editor_id'] = f"{profile.id}"
+            #profile = client.get_profile(arr_metareview.tauthor)
+            #acl_metareview.content['action_editor_id'] = f"{profile.id}"
             acl_metareview_posted = client.post_note(acl_metareview)
             assert acl_metareview_posted, print('failed to post metareview ', acl_metareview.id)
             acl_metareviews_dictionary[acl_metareview_posted.signatures[0]] = acl_metareview_posted.replyto

--- a/venues/aclweb.org/Workshops/migrate_submissions_workshops_one.py
+++ b/venues/aclweb.org/Workshops/migrate_submissions_workshops_one.py
@@ -24,7 +24,7 @@ confid = args.confid
 # Post acl submission (calls post_blind_submission)
 def post_acl_submission(arr_submission_forum, acl_commitment_note, submission_output_dict):
     # Depends on the workshop
-    eligible_arr_invitations = ['aclweb.org/ACL/ARR/2021/May/', 'aclweb.org/ACL/ARR/2021/Jun/', 'aclweb.org/ACL/ARR/2021/July/', 'aclweb.org/ACL/ARR/2021/August/', 'aclweb.org/ACL/ARR/2021/September/','aclweb.org/ACL/ARR/2021/October/','aclweb.org/ACL/ARR/2021/November/', 'aclweb.org/ACL/ARR/2021/December/', 'aclweb.org/ACL/ARR/2022/January/' ,'aclweb.org/ACL/ARR/2022/February/']
+    eligible_arr_invitations = ['aclweb.org/ACL/ARR/2021/May/', 'aclweb.org/ACL/ARR/2021/Jun/', 'aclweb.org/ACL/ARR/2021/July/', 'aclweb.org/ACL/ARR/2021/August/', 'aclweb.org/ACL/ARR/2021/September/','aclweb.org/ACL/ARR/2021/October/','aclweb.org/ACL/ARR/2021/November/', 'aclweb.org/ACL/ARR/2021/December/', 'aclweb.org/ACL/ARR/2022/January/' ,'aclweb.org/ACL/ARR/2022/February/', 'aclweb.org/ACL/ARR/2022/March/', 'aclweb.org/ACL/ARR/2022/April/']
     original_arr_sub_id = None
     #submission_output_dict['acl_commitment_forum'] = acl_commitment_note.forum
     try:

--- a/venues/aclweb.org/Workshops/post_camera_ready.py
+++ b/venues/aclweb.org/Workshops/post_camera_ready.py
@@ -31,7 +31,7 @@ super_invitation = openreview.Invitation(
     reply={
         "content": {
             "title": {
-      "description": "Enter the title of the ARR submission that you want to commit to SPA-NLP",
+      "description": "Enter the title of the ARR submission that you want to commit to MIA",
       "order": 1,
       "value-regex": ".{1,250}",
       "required": False
@@ -61,15 +61,15 @@ super_invitation = openreview.Invitation(
       "required": False,
       "order": 10
     },
-    "paper_type": {
-      "description": "Select if your paper is short or long",
-      "value-radio": [
-        "short",
-        "long"
-      ],
-      "required": False,
-      "order": 11
-    },
+    "archival": {
+"description": "Please indicate if you want your paper to be archival or non-archival.",
+"value-radio": [
+"Archival",
+"Non-Archival"
+],
+"order": 13,
+"required": False
+},
     "abstract": {
       "description": "Abstract of paper. Add TeX formulas using the following formats: $In-line Formula$ or $$Block Formula$$.",
       "order": 14,

--- a/venues/aclweb.org/Workshops/post_camera_ready_author_order.py
+++ b/venues/aclweb.org/Workshops/post_camera_ready_author_order.py
@@ -1,0 +1,129 @@
+import argparse
+import openreview
+from tqdm import tqdm
+import csv
+from openreview import tools
+import re
+from collections import defaultdict
+
+"""
+OPTIONAL SCRIPT ARGUMENTS
+    baseurl -  the URL of the OpenReview server to connect to (live site: https://openreview.net)
+    username - the email address of the logging in user
+    password - the user's password
+"""
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base URL")
+parser.add_argument('--username')
+parser.add_argument('--password')
+parser.add_argument('--confid')
+
+args = parser.parse_args()
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+confid = args.confid
+super_invitation = openreview.Invitation(
+    id=f'{confid}/-/Commitment_Camera_Ready_Revision',
+    duedate=1651622834000, # March 15
+    multiReply=True,
+    readers=['everyone'],
+    writers=[confid],
+    signatures=[confid]  
+)
+client.post_invitation(super_invitation)
+submissions=list(openreview.tools.iterget_notes(client, invitation=f'{confid}/-/Blind_Commitment_Submission', details = 'original'))
+decision_by_forum={ d.forum: d for d in list(openreview.tools.iterget_notes(client, invitation=f'{confid}/Commitment.*/-/Decision'))}
+short_phrase = confid.split('/')[-1]  
+for submission in tqdm(submissions):
+    print(submission.original)
+    with open('camera_ready_process.py') as d:
+      content = d.read()
+      short_phrase = confid.split('/')[-1]
+      process = content.replace("SHORT_PHRASE = ''", f"SHORT_PHRASE = '{short_phrase}'")
+      process = process.replace("AUTHOR_ID = ''", f"AUTHOR_ID = '{confid}/Commitment{submission.number}/Authors'")
+    original_submission = client.get_note(submission.original)
+    
+    decision = decision_by_forum.get(submission.id)
+    if decision:
+        if 'Accept' in decision.content['decision']:
+            r=client.post_invitation(openreview.Invitation(
+                id=f'{confid}/Commitment{submission.number}/-/Camera_Ready_Revision',
+                super=f'{confid}/-/Commitment_Camera_Ready_Revision',
+                writers=[confid],
+                signatures=[confid],
+                readers=['everyone'],
+                invitees=[confid, f'{confid}/Commitment{submission.number}/Authors'],
+                process_string = process,
+                reply={
+                    'forum': original_submission.id,
+                    'referent': original_submission.id,
+                    'readers': {
+                        'values': [
+                            confid,
+                            f'{confid}/Commitment{submission.number}/Authors'
+                        ]
+                    },
+                    'writers': {
+                        'values': [
+                            confid,
+                            f'{confid}/Commitment{submission.number}/Authors'
+                        ]
+                    },
+                    'signatures': {
+                        'values-regex': f'{confid}/Program_Chairs|{confid}/Commitment{submission.number}/Authors'
+                    },
+                    'content':   {
+                          'authors': {
+                              'values': submission.details["original"]["content"]['authors'],
+                              'required': True,
+                              'hidden': True,
+                              'order': 2
+                          },
+                          'authorids': {
+                              'values': submission.details["original"]["content"]['authorids'],
+                              'required': True,
+                              'order': 3
+                          },
+                          "title": {
+                            "description": "Enter the title of the ARR submission that you want to commit to MIA",
+                            "order": 1,
+                            "value-regex": ".{1,250}",
+                            "required": False
+                          },
+                          "existing_preprints": {
+                            "values-regex": ".{1,500}",
+                            "description": "If there are any publicly available non-anonymous preprints of this paper, please list them here (provide the URLs please).",
+                            "required": False,
+                            "order": 7
+                          },
+                          "archival": {
+                            "description": "Please indicate if you want your paper to be archival or non-archival.",
+                            "value-radio": [
+                            "Archival",
+                            "Non-Archival"
+                            ],
+                            "order": 8,
+                            "required": False
+                        },
+                        "abstract": {
+                          "description": "Abstract of paper. Add TeX formulas using the following formats: $In-line Formula$ or $$Block Formula$$.",
+                          "order": 4,
+                          "value-regex": "[\\S\\s]{1,5000}",
+                          "required": False
+                        },
+                        "pdf": {
+                          "description": "Upload a single PDF containing the paper, references and any appendices. Please refer to the CFP (https://aclrollingreview.org/cfp) and author checklist (https://aclrollingreview.org/authorchecklist). Failure to follow the rules regarding format, anonymization, authorship, citation and comparison, and multiple submission will lead to desk rejection.",
+                          "order": 5,
+                          "value-file": {
+                            "fileTypes": [
+                              "pdf"
+                            ],
+                            "size": 80
+                          },
+                          "required": False
+                        }
+                    }                  
+                }
+            ))
+            
+    else:
+        print('decision not found')

--- a/venues/aclweb.org/Workshops/post_withdraw_invitations.py
+++ b/venues/aclweb.org/Workshops/post_withdraw_invitations.py
@@ -1,0 +1,176 @@
+import argparse
+from re import sub
+import openreview
+from tqdm import tqdm
+import csv
+
+"""
+OPTIONAL SCRIPT ARGUMENTS
+
+    baseurl -  the URL of the OpenReview server to connect to (live site: https://openreview.net)
+    username - the email address of the logging in user
+    password - the user's password
+
+"""
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base URL")
+parser.add_argument('--username')
+parser.add_argument('--password')
+parser.add_argument('--confid')
+args = parser.parse_args()
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+confid = args.confid
+
+desk_rejected_invitation = client.post_invitation(openreview.Invitation(
+    id = f"{confid}/-/Withdrawn_Commitment_Submission",
+    writers = [confid],
+    readers = [confid],
+    signatures = [confid],
+    reply = {
+        "readers": {
+            "values-regex": ".*"
+        },
+        "writers": {
+            "values": [
+                confid
+            ]
+        },
+        "signatures": {
+            "values": [
+                confid
+            ]
+        },
+        "content": {
+            "authorids": {
+                "values-regex": ".*"
+                },
+            "authors": {
+                "values": [
+                    "Anonymous"
+                ]
+            },
+            "title": {
+      "value-regex": ".*"
+    },
+    "abstract": {
+      "value-regex": ".*"
+    },
+    "pdf": {
+      "value-regex": ".*"
+    },
+    "software": {
+      "value-regex": ".*"
+    },
+    "data": {
+      "value-regex": ".*"
+    },
+    "paper_link": {
+      "value-regex": ".*"
+    },
+    "paper_type": {
+      "value-regex": ".*"
+    },
+    "track": {
+      "value-regex": ".*"
+    },
+    "comment": {
+      "value-regex": ".*"
+    },
+    "authorship": {
+      "value-regex": ".*"
+    },
+    "paper_version": {
+      "value-regex": ".*"
+    },
+    "anonymity_period": {
+      "value-regex": ".*"
+    },
+    "commitment_note": {
+      "value-regex": ".*"
+    },
+    "ACL_preprint": {
+      "value-regex": ".*"
+    },
+    "preprint": {
+      "value-regex": ".*"
+    },
+    "existing_preprints": {
+      "value-regex": ".*"
+    },
+    "previous_URL": {
+      "value-regex": ".*"
+    },
+    "TL;DR": {
+      "value-regex": ".*"
+    },
+    "author_profiles": {
+      "value-regex": ".*"
+    },
+    "country_of_affiliation_of_corresponding_author": {
+      "value-regex": ".*"
+    },
+    "paper_link": {
+      "value-regex": ".*"
+    }
+        }
+    }
+))
+
+
+
+# Get all ACL 2022 Conference blind submissions
+acl_blind_submissions = list(openreview.tools.iterget_notes(client, invitation = f'{confid}/-/Blind_Commitment_Submission'))
+
+# For each blind submission, set the readers to the SAC track group
+for acl_blind_submission in tqdm(acl_blind_submissions):
+    with open('withdraw-ACL-process.py') as d:
+      content = d.read()
+      short_phrase = confid.split('/')[-1]
+      process = content.replace("CONFERENCE_SHORT_NAME = ''", f"CONFERENCE_SHORT_NAME = '{short_phrase}'")
+      process = process.replace("WITHDRAWN_SUBMISSION_ID = ''", f"WITHDRAWN_SUBMISSION_ID = '{confid}/-/Withdrawn_Commitment_Submission'")
+      process = process.replace("PAPER_AUTHORS_ID = ''", f"PAPER_AUTHORS_ID = '{confid}/Commitment{acl_blind_submission.number}/Authors'")
+    author_group = f'{confid}/Commitment{acl_blind_submission.number}/Authors'
+    conflict_id = f'{confid}/Commitment{acl_blind_submission.number}/Conflicts'
+    desk_reject = client.post_invitation(openreview.Invitation(
+        id = f"{confid}/Commitment{acl_blind_submission.number}/-/Withdraw",
+        invitees = [f"{confid}/Program_Chairs","OpenReview.net/Support", author_group],
+        readers = ["everyone"],
+        writers = [confid],
+        signatures = ["~Super_User1"],
+        reply = {
+            "forum": acl_blind_submission.forum,
+            "replyto": acl_blind_submission.forum,
+            "readers": {
+                "values": [
+                    f"{confid}/Program_Chairs",
+                    author_group
+                ]
+                },
+            "writers": {
+                "values-copied": [
+                    confid,
+                    "{signatures}"
+                ]
+            },            
+            "signatures": {
+                "values": [
+                    author_group
+                ],
+                "description": "How your identity will be displayed."
+                },
+            "content": {
+                "title": {
+                    "value": "Submission Withdrawn by Paper Authors",
+                    "order": 1
+                },
+            "withdrawal confirmation": {
+                "description": "Please confirm to withdraw.",
+                "value-radio": [
+                    "I have read and agree with the venue's withdrawal policy on behalf of myself and my co-authors."
+                ],
+                "order": 2,
+                "required": True
+                }
+            }},
+            process_string = process
+                ))

--- a/venues/aclweb.org/Workshops/withdraw-ACL-process.py
+++ b/venues/aclweb.org/Workshops/withdraw-ACL-process.py
@@ -1,0 +1,33 @@
+def process(client, note, invitation):
+    from datetime import datetime
+    CONFERENCE_SHORT_NAME = ''
+    WITHDRAWN_SUBMISSION_ID = ''
+
+    forum_note = client.get_note(note.forum)
+    forum_note.invitation = WITHDRAWN_SUBMISSION_ID
+    
+    
+    
+    forum_note.content = {
+    'authors': forum_note.content['authors'],
+    'authorids': forum_note.content['authorids']
+    }
+    forum_note = client.post_note(forum_note)
+
+
+    # Mail to the submission readers
+    email_subject = '''{CONFERENCE_SHORT_NAME}: Paper #{paper_number} titled "{paper_title}" withdrawn by authors'''.format(
+        CONFERENCE_SHORT_NAME=CONFERENCE_SHORT_NAME,
+        paper_number=forum_note.number,
+        paper_title=forum_note.content['title']
+    )
+    email_body = '''The {CONFERENCE_SHORT_NAME} paper "{paper_title_or_num}" has been withdrawn by the paper authors.'''.format(
+        CONFERENCE_SHORT_NAME=CONFERENCE_SHORT_NAME,
+        paper_title_or_num=forum_note.content.get('title', '#'+str(forum_note.number))
+    )
+
+    PAPER_AUTHORS_ID = ''
+
+    recipients = note.readers
+    recipients.append(PAPER_AUTHORS_ID)
+    client.post_message(subject=email_subject, recipients=recipients, message=email_body, ignoreRecipients=note.nonreaders)


### PR DESCRIPTION
Includes an extra camera-ready revision script for venues that want to allow for the author list to be reordered but not allow the addition or removal of authors. 