### PR TITLE
Feat: Neurips submission pre-process

### DIFF
--- a/venues/NeurIPS.cc/2023/submission_preprocess.js
+++ b/venues/NeurIPS.cc/2023/submission_preprocess.js
@@ -44,10 +44,7 @@ async function process(client, edit, invitation) {
     for (const profile of profiles) {
       const emails = profile.content.emails
       const usernames = profile.content.names.map(name => name.username).filter(username => username);
-      const cleanUsernames = usernames.filter(function( element ) {
-        return element !== undefined;
-      });
-      const allIds = emails.concat(cleanUsernames)
+      const allIds = emails.concat(usernames)
       for (const username of allIds) {
         if (reviewerMembers[username]) {
           const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Reviewers/-/Registration', signatures: allIds })

--- a/venues/NeurIPS.cc/2023/submission_preprocess.js
+++ b/venues/NeurIPS.cc/2023/submission_preprocess.js
@@ -49,33 +49,10 @@ async function process(client, edit, invitation) {
       acMembers[ac] = true
     }
 
-    // var allIds; 
-    // profiles.forEach(async function(profile) {
-    //   const emails = profile.content.emails
-    //   const usernames = profile.content.names.map(name => name.username)
-    //   allIds = emails.concat(usernames)
-    //   for (const username of allIds) {
-    //     if (reviewerMembers[username]) {
-    //       const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Reviewers/-/Registration', signatures: [allIds] })
-    //       if (noteCount === 0) {
-    //         return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Reviewer ' + username + ' has not completed the Reviewer Registration.' }))
-    //       }
-    //     }
-    //     if (acMembers[username]) {
-    //       const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Area_Chairs/-/Registration', signatures: [allIds] })
-    //       if (noteCount === 0) {
-    //         return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Area Chair ' + username + ' has not completed the Area Chair Registration.' }))
-    //       }
-    //     }
-    //   }
-    // })
-
-    var allIds; 
-    for(var i=0;i<profiles.length;i++) {
-      const profile = profiles[i]
+    for (const profile of profiles) {
       const emails = profile.content.emails
       const usernames = profile.content.names.map(name => name.username)
-      allIds = emails.concat(usernames)
+      const allIds = emails.concat(usernames)
       for (const username of allIds) {
         if (reviewerMembers[username]) {
           const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Reviewers/-/Registration', signatures: [allIds] })

--- a/venues/NeurIPS.cc/2023/submission_preprocess.js
+++ b/venues/NeurIPS.cc/2023/submission_preprocess.js
@@ -41,27 +41,26 @@ async function process(client, edit, invitation) {
       reviewerMembers[reviewer] = true
     }
 
-    const { groups: acGroups } = await client.getGroups({ id: invitation.domain + '/Area_Chairs' })
-    const acs = acGroups[0].members;
-    
-    const acMembers = {}
-    for (const ac of acs) {
-      acMembers[ac] = true
-    }
-
     for (const profile of profiles) {
       const emails = profile.content.emails
       const usernames = profile.content.names.map(name => name.username)
       const allIds = emails.concat(usernames)
       for (const username of allIds) {
         if (reviewerMembers[username]) {
-          const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Reviewers/-/Registration', signatures: [allIds] })
+          const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Reviewers/-/Registration', signatures: allIds })
           if (noteCount === 0) {
             return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Reviewer ' + client.tools.prettyId(username) + ' has not completed the Reviewer Registration.' }))
           }
         }
+        const { groups: acGroups } = await client.getGroups({ id: invitation.domain + '/Area_Chairs' })
+        const acs = acGroups[0].members;
+        
+        const acMembers = {}
+        for (const ac of acs) {
+          acMembers[ac] = true
+        }
         if (acMembers[username]) {
-          const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Area_Chairs/-/Registration', signatures: [allIds] })
+          const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Area_Chairs/-/Registration', signatures: allIds })
           if (noteCount === 0) {
             return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Area chair ' + client.tools.prettyId(username) + ' has not completed the Area Chair Registration.' }))
           }

--- a/venues/NeurIPS.cc/2023/submission_preprocess.js
+++ b/venues/NeurIPS.cc/2023/submission_preprocess.js
@@ -44,7 +44,10 @@ async function process(client, edit, invitation) {
     for (const profile of profiles) {
       const emails = profile.content.emails
       const usernames = profile.content.names.map(name => name.username)
-      const allIds = emails.concat(usernames)
+      const cleanUsernames = usernames.filter(function( element ) {
+        return element !== undefined;
+      });
+      const allIds = emails.concat(cleanUsernames)
       for (const username of allIds) {
         if (reviewerMembers[username]) {
           const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Reviewers/-/Registration', signatures: allIds })

--- a/venues/NeurIPS.cc/2023/submission_preprocess.js
+++ b/venues/NeurIPS.cc/2023/submission_preprocess.js
@@ -43,7 +43,7 @@ async function process(client, edit, invitation) {
 
     for (const profile of profiles) {
       const emails = profile.content.emails
-      const usernames = profile.content.names.map(name => name.username)
+      const usernames = profile.content.names.map(name => name.username).filter(username => username);
       const cleanUsernames = usernames.filter(function( element ) {
         return element !== undefined;
       });

--- a/venues/NeurIPS.cc/2023/submission_preprocess.js
+++ b/venues/NeurIPS.cc/2023/submission_preprocess.js
@@ -1,0 +1,94 @@
+async function process(client, edit, invitation) {
+    client.throwErrors = true
+    
+    const { note } = edit
+
+    if (note.ddate) { 
+      return
+    }
+
+    const profiles = await client.tools.getProfiles(note.content.authorids.value)
+    const profileIds = profiles.map(profile => profile.id)
+
+    const primaryAuthorField = note.content.corresponding_author.value
+    const primaryAuthorProfile = await client.tools.getProfiles([primaryAuthorField])
+    const primaryAuthor = primaryAuthorProfile ? primaryAuthorProfile[0].id : primaryAuthorField
+    if (!profileIds.includes(primaryAuthor)) {
+      return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Select a paper co-author as corresponding author, ' + primaryAuthorField + ' does not appear in the author list' }))
+    }
+
+    if (note.content.financial_support) {
+      const financialSupportField = note.content.financial_support.value
+      const financialSupportProfile = await client.tools.getProfiles([financialSupportField])
+      const financialSupport = financialSupportProfile ? financialSupportProfile[0].id : financialSupportField
+      if (!profileIds.includes(financialSupport)) {
+        return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Select a paper co-author for financial support, ' + financialSupportField + ' does not appear in the author list' }))
+      }
+    }
+
+    const reviewerNominationField = note.content.reviewer_nomination.value
+    const reviewerNominationProfile = await client.tools.getProfiles([reviewerNominationField])
+    const reviewerNomination = reviewerNominationProfile ? reviewerNominationProfile[0].id : reviewerNominationField
+    if (!profileIds.includes(reviewerNomination)) {
+      return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Select a paper co-author to nominate as reviewer, ' + reviewerNominationField + ' does not appear in the author list' }))
+    }
+
+    const { groups: revGroups } = await client.getGroups({ id: invitation.domain + '/Reviewers' })
+    const reviewers = revGroups[0].members;
+    
+    const reviewerMembers = {}
+    for (const reviewer of reviewers) {
+      reviewerMembers[reviewer] = true
+    }
+
+    const { groups: acGroups } = await client.getGroups({ id: invitation.domain + '/Area_Chairs' })
+    const acs = acGroups[0].members;
+    
+    const acMembers = {}
+    for (const ac of acs) {
+      acMembers[ac] = true
+    }
+
+    // var allIds; 
+    // profiles.forEach(async function(profile) {
+    //   const emails = profile.content.emails
+    //   const usernames = profile.content.names.map(name => name.username)
+    //   allIds = emails.concat(usernames)
+    //   for (const username of allIds) {
+    //     if (reviewerMembers[username]) {
+    //       const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Reviewers/-/Registration', signatures: [allIds] })
+    //       if (noteCount === 0) {
+    //         return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Reviewer ' + username + ' has not completed the Reviewer Registration.' }))
+    //       }
+    //     }
+    //     if (acMembers[username]) {
+    //       const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Area_Chairs/-/Registration', signatures: [allIds] })
+    //       if (noteCount === 0) {
+    //         return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Area Chair ' + username + ' has not completed the Area Chair Registration.' }))
+    //       }
+    //     }
+    //   }
+    // })
+
+    var allIds; 
+    for(var i=0;i<profiles.length;i++) {
+      const profile = profiles[i]
+      const emails = profile.content.emails
+      const usernames = profile.content.names.map(name => name.username)
+      allIds = emails.concat(usernames)
+      for (const username of allIds) {
+        if (reviewerMembers[username]) {
+          const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Reviewers/-/Registration', signatures: [allIds] })
+          if (noteCount === 0) {
+            return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Reviewer ' + username + ' has not completed the Reviewer Registration.' }))
+          }
+        }
+        if (acMembers[username]) {
+          const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Area_Chairs/-/Registration', signatures: [allIds] })
+          if (noteCount === 0) {
+            return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Area Chair ' + username + ' has not completed the Area Chair Registration.' }))
+          }
+        }
+      }
+    }
+}

--- a/venues/NeurIPS.cc/2023/submission_preprocess.js
+++ b/venues/NeurIPS.cc/2023/submission_preprocess.js
@@ -12,7 +12,7 @@ async function process(client, edit, invitation) {
 
     const primaryAuthorField = note.content.corresponding_author.value
     const primaryAuthorProfile = await client.tools.getProfiles([primaryAuthorField])
-    const primaryAuthor = primaryAuthorProfile ? primaryAuthorProfile[0].id : primaryAuthorField
+    const primaryAuthor = primaryAuthorProfile[0].id
     if (!profileIds.includes(primaryAuthor)) {
       return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Select a paper co-author as corresponding author, ' + primaryAuthorField + ' does not appear in the author list' }))
     }
@@ -20,7 +20,7 @@ async function process(client, edit, invitation) {
     if (note.content.financial_support) {
       const financialSupportField = note.content.financial_support.value
       const financialSupportProfile = await client.tools.getProfiles([financialSupportField])
-      const financialSupport = financialSupportProfile ? financialSupportProfile[0].id : financialSupportField
+      const financialSupport = financialSupportProfile[0].id
       if (!profileIds.includes(financialSupport)) {
         return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Select a paper co-author for financial support, ' + financialSupportField + ' does not appear in the author list' }))
       }
@@ -28,7 +28,7 @@ async function process(client, edit, invitation) {
 
     const reviewerNominationField = note.content.reviewer_nomination.value
     const reviewerNominationProfile = await client.tools.getProfiles([reviewerNominationField])
-    const reviewerNomination = reviewerNominationProfile ? reviewerNominationProfile[0].id : reviewerNominationField
+    const reviewerNomination = reviewerNominationProfile[0].id
     if (!profileIds.includes(reviewerNomination)) {
       return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Select a paper co-author to nominate as reviewer, ' + reviewerNominationField + ' does not appear in the author list' }))
     }
@@ -57,13 +57,13 @@ async function process(client, edit, invitation) {
         if (reviewerMembers[username]) {
           const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Reviewers/-/Registration', signatures: [allIds] })
           if (noteCount === 0) {
-            return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Reviewer ' + username + ' has not completed the Reviewer Registration.' }))
+            return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Reviewer ' + client.tools.prettyId(username) + ' has not completed the Reviewer Registration.' }))
           }
         }
         if (acMembers[username]) {
           const { count: noteCount } = await client.getNotes({ invitation: 'NeurIPS.cc/2023/Conference/Area_Chairs/-/Registration', signatures: [allIds] })
           if (noteCount === 0) {
-            return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Area Chair ' + username + ' has not completed the Area Chair Registration.' }))
+            return Promise.reject(new OpenReviewError({ name: 'Error', message: 'Area chair ' + client.tools.prettyId(username) + ' has not completed the Area Chair Registration.' }))
           }
         }
       }


### PR DESCRIPTION
The pre-process checks two things:
- that the user entered in fields `corresponding_author`, `financial_support` and `reviewer_nomination` is a co-author of the paper
- that if any co-author is a reviewer or AC, they have completed the registration task

Comment: the commented out code is how I tried to do it at first, but it was not working. I *think* it's because the thrown error would exit the inside function, but the outside one didn't know which error was being thrown (the user would just see "Something went wrong")
Is there a better way to do this?